### PR TITLE
Assign assign reviewer & include link in doc sync PR

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -8,6 +8,12 @@ on:
         required: true
         type: string
 
+      reviewer:
+        description: |
+          Who to assign as PR reviewer (default: you)
+        required: false
+        type: string
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -92,7 +98,7 @@ jobs:
           git push -u origin "automation/sync-${{ inputs.version }}"
         working-directory: pantsbuild.org
       - name: Make a PR
-        run: gh pr create --title "Update docs site for version ${{ inputs.version }}" --body "Docs from https://github.com/pantsbuild/pants/releases/tag/release_${{ inputs.version }}"
+        run: gh pr create --title "Update docs site for version ${{ inputs.version }}" --body "Docs from https://github.com/pantsbuild/pants/releases/tag/release_${{ inputs.version }}" --reviewer "${{ inputs.reviewer || github.actor }}"
         env:
           GH_TOKEN: ${{ github.token }}
         working-directory: pantsbuild.org

--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -92,7 +92,7 @@ jobs:
           git push -u origin "automation/sync-${{ inputs.version }}"
         working-directory: pantsbuild.org
       - name: Make a PR
-        run: gh pr create --title "Update docs site for version ${{ inputs.version }}" --body ""
+        run: gh pr create --title "Update docs site for version ${{ inputs.version }}" --body "Docs from https://github.com/pantsbuild/pants/releases/tag/release_${{ inputs.version }}"
         env:
           GH_TOKEN: ${{ github.token }}
         working-directory: pantsbuild.org


### PR DESCRIPTION
This does two minor adjustments to the PR that is created for syncing docs:

1. include a link to the relevant release (fixes #13)
2. assign a reviewer, by default the person triggering the workflow but can be overridden as an input (fixes #12)

Examples: #31 (default reviewer), #32 (providing reviewer input `thejcannon,huonw`)