### PR TITLE
Handle `undefined` better in `docusaurus.config.js`

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,8 +19,9 @@ function getCurrentVersion() {
 //  - PANTSBUILD_ORG_INCLUDE_BLOG=1 -> Include the blog.
 // Note that `NODE_ENV === 'production' builds _everything_.
 const isDev = process.env.NODE_ENV === "development";
-const disableVersioning =
-  isDev && process.env.PANTSBUILD_ORG_INCLUDE_VERSIONS === undefined;
+const disableVersioning = isDev
+  ? process.env.PANTSBUILD_ORG_INCLUDE_VERSIONS === undefined
+  : undefined;
 const onlyIncludeVersions = isDev
   ? process.env.PANTSBUILD_ORG_INCLUDE_VERSIONS
     ? ["current"].concat(
@@ -29,7 +30,9 @@ const onlyIncludeVersions = isDev
     : ["current"]
   : undefined;
 const currentVersion = getCurrentVersion();
-const includeBlog = process.env.PANTSBUILD_ORG_INCLUDE_BLOG === "1" || !isDev;
+const includeBlog = isDev
+  ? process.env.PANTSBUILD_ORG_INCLUDE_BLOG === "1"
+  : undefined;
 
 const config = {
   title: "Pantsbuild",
@@ -63,7 +66,7 @@ const config = {
               label: `${currentVersion} (dev)`,
               path: currentVersion,
             },
-            ...(disableVersioning
+            ...(disableVersioning === undefined
               ? {}
               : versions.reduce((acc, version, index) => {
                   acc[version] = {


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pantsbuild.org/issues/7 by being more methodical about `isDev` and `undefined` values.

The crux of the issue was the bad ternary test on line 66.

Tested with `npm run build && npm run serve` and going to `localhost:3000/foo`