### PR TITLE
Generate reference docs with all backends enabled

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -25,7 +25,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Generate help JSON
         # First run `help-all` which will contain the list of every backend in the `name_to_backend_help_info` object,
-        # then, run it again with every backend enabled.
+        # then run it again with every backend enabled.
         # NB: We run the command initially twice, since the first run might put extraneous crap on stdout.
         run: |
           touch pants.toml

--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -24,11 +24,14 @@ jobs:
           curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Generate help JSON
-        # Run the command twice, since the first run might put extraneous crap on stdout
+        # First run `help-all` which will contain the list of every backend in the `name_to_backend_help_info` object,
+        # then, run it again with every backend enabled.
+        # NB: We run the command initially twice, since the first run might put extraneous crap on stdout.
         run: |
           touch pants.toml
           PANTS_VERSION="${{ inputs.version }}" pants help-all > /dev/null
           PANTS_VERSION="${{ inputs.version }}" pants help-all > help-all.json
+          PANTS_VERSION="${{ inputs.version }}" pants --backend-packages=[$(jq -r '.name_to_backend_help_info | keys_unsorted | map("\"" + . + "\"") | join(",")' help-all.json)] help-all > help-all.json
 
       # Checkout both repos
       - name: Checkout pants repo


### PR DESCRIPTION
This change fixes https://github.com/pantsbuild/pantsbuild.org/issues/42 by re-running the `help-all` command with every backend enabled. The list of backends is calculated by using all the keys of `.name_to_backend_help_info` from a run of `help-all`.