### PR TITLE
Fix doc syncing for `.x` removal

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -60,8 +60,8 @@ jobs:
           echo "DESTINATION_DIR=$(echo "$DESTINATION_DIR")" | tee -a "${GITHUB_OUTPUT}"
       - run: |
           rm -rf "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
-          mkdir "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
-          cp help-all.json "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
+          mkdir -p "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}/reference"
+          cp help-all.json "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}/reference"
 
       # Generate reference docs
       - name: Setup Node

--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -49,17 +49,15 @@ jobs:
           path: pantsbuild.org
 
       # Calculate destination
-      - name: Calculate branch name
-        id: get-branch-name
-        run: echo "BRANCH_NAME=$(echo "${{ inputs.version }}" | sed -E 's/^([0-9]+)\.([0-9]+)\.\w+.*/\1.\2.x/')" >> "${GITHUB_OUTPUT}"
       - name: Calculate destination
         id: get-destination-dir
         run: |
-          DESTINATION_DIR="versioned_docs/version-${{ steps.get-branch-name.outputs.BRANCH_NAME }}"
+          BASE_VERSION=$(echo "${{ inputs.version }}" | sed -E 's/^([0-9]+)\.([0-9]+)\.\w+.*/\1.\2/')
+          DESTINATION_DIR="versioned_docs/version-$BASE_VERSION"
           if [ ! -d "pantsbuild.org/$DESTINATION_DIR" ]; then
             DESTINATION_DIR="docs"
           fi
-          echo "DESTINATION_DIR=$(echo "$DESTINATION_DIR")" >> "${GITHUB_OUTPUT}"
+          echo "DESTINATION_DIR=$(echo "$DESTINATION_DIR")" | tee -a "${GITHUB_OUTPUT}"
       - run: |
           rm -rf "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
           mkdir "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"


### PR DESCRIPTION
This fixes the doc syncer now that we don't have `.x` in the directories (#48), per https://github.com/pantsbuild/pantsbuild.org/pull/48#issuecomment-1876073051

It also makes an unrelated fix, so that my test works.

Test: #57, https://github.com/pantsbuild/pantsbuild.org/actions/runs/7403672327/job/20143898054 