### PR TITLE
Include version in doc syncing run name

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -1,4 +1,6 @@
 name: Sync the Docs
+run-name: >-
+  Sync the Docs: version ${{ inputs.version }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This adjusts the Sync docs action to include the version in the "run-name" (https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name), so that the Actions listing https://github.com/pantsbuild/pantsbuild.org/actions/workflows/sync_docs.yml is more informative:

![image](https://github.com/pantsbuild/pantsbuild.org/assets/1203825/a529efcc-72e5-4c63-89cc-3ac9ef180a4b)
