### PR TITLE
Update the URL

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,7 +33,7 @@ const config = {
   tagline: "The ergonomic build system",
   favicon: "img/favicon.ico",
 
-  url: "https://pantsbuild.github.io",
+  url: "https://docs.pantsbuild.org",
   baseUrl: "/",
   trailingSlash: false,
 


### PR DESCRIPTION
I have a small suspicion this is why https://github.com/pantsbuild/pantsbuild.org/issues/45 is happening.

See the sitemap.xml: https://docs.pantsbuild.org/sitemap.xml