### PR TITLE
Render `target_field_name` information

### DIFF
--- a/src/components/reference/Option.jsx
+++ b/src/components/reference/Option.jsx
@@ -4,6 +4,7 @@ export default function Option({
   env_repr,
   one_of,
   default_repr,
+  target_field_name,
   removal_version,
   removal_hint,
 }) {
@@ -47,6 +48,11 @@ export default function Option({
           </span>
         )}
         {children}
+        {target_field_name && (
+          <span>Can be overriden by field
+            <code>{target_field_name}</code> on <code>local_environment</code>, <code>docker_environment</code>,
+            or <code>remote_environment</code> targets.</span>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Looks like the component was missing the part about `target_field_name` from https://github.com/pantsbuild/pants/commit/8cabd7d123428d5631b6ffd7d06722c146c1a18d