### PR TITLE
Include link to pantsbuild.org repo and commit in footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,6 +4,9 @@ import captionedCode from "./src/remark/captioned-code.js";
 
 import { themes as prismThemes } from "prism-react-renderer";
 
+const organizationName = "pantsbuild";
+const projectName = "pantsbuild.org";
+
 function getCurrentVersion() {
   const lastReleasedVersion = versions[0];
   const version = parseInt(lastReleasedVersion.replace("2.", ""), 10);
@@ -28,6 +31,23 @@ const onlyIncludeVersions = isDev
 const currentVersion = getCurrentVersion();
 const includeBlog = process.env.PANTSBUILD_ORG_INCLUDE_BLOG === "1" || !isDev;
 
+const formatCopyright = () => {
+  const year = new Date().getFullYear();
+
+  const makeLink = (href, text) => `<a href="${href}">${text}</a>`;
+
+  const repoUrl = `https://github.com/${organizationName}/${projectName}`;
+  const repoLink = makeLink(repoUrl, "Website source");
+
+  // Only set by CI, so fallback to just `local` for local dev
+  const docsCommit = process.env.GITHUB_SHA;
+  const commitLink = docsCommit
+    ? makeLink(`${repoUrl}/commit/${docsCommit}`, docsCommit.slice(0, 6))
+    : "local";
+
+  return `Copyright © ${year} Pants project contributors. ${repoLink} @ ${commitLink}.`;
+};
+
 const config = {
   title: "Pantsbuild",
   tagline: "The ergonomic build system",
@@ -37,8 +57,8 @@ const config = {
   baseUrl: "/",
   trailingSlash: false,
 
-  organizationName: "pantsbuild",
-  projectName: "pantsbuild.org",
+  organizationName,
+  projectName,
 
   // @TODO: This should throw on prod
   onBrokenLinks: isDev ? "warn" : "warn",
@@ -251,7 +271,7 @@ const config = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} Pants project contributors. Built with Docusaurus.`,
+      copyright: formatCopyright(),
     },
     algolia: {
       appId: "QD9KY1TRVK",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -32,8 +32,6 @@ const currentVersion = getCurrentVersion();
 const includeBlog = process.env.PANTSBUILD_ORG_INCLUDE_BLOG === "1" || !isDev;
 
 const formatCopyright = () => {
-  const year = new Date().getFullYear();
-
   const makeLink = (href, text) => `<a href="${href}">${text}</a>`;
 
   const repoUrl = `https://github.com/${organizationName}/${projectName}`;
@@ -45,7 +43,7 @@ const formatCopyright = () => {
     ? makeLink(`${repoUrl}/commit/${docsCommit}`, docsCommit.slice(0, 6))
     : "local";
 
-  return `Copyright © ${year} Pants project contributors. ${repoLink} @ ${commitLink}.`;
+  return `Copyright © Pants project contributors. ${repoLink} @ ${commitLink}.`;
 };
 
 const config = {


### PR DESCRIPTION
This adjusts the "copyright" section of the website footer to include:

- a link to this repository, replacing the "built with docusaurus" text, since that can be discovered by clicking through to the repo (it be fine to continue to include that if required).
- a reference to which commit the deployed website is showing, so we can be sure we're looking at what we expect (it would be fine to move this to a HTML comment instead, so it's just available for reference in the rare case it's required).

Example:

![image](https://github.com/pantsbuild/pantsbuild.org/assets/1203825/de90e756-08a3-4260-a6e4-0803fe152354)
