### PR TITLE
Check reference docs are up to date in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,22 @@ jobs:
       - run: yarn install --frozen-lockfile
       - name: Check formatting
         run: npm run check-formatting
+
+      - name: Check references are up to date
+        # NB. in future, it would be nice for this to be packaged as a test that one can run
+        # locally, e.g. https://github.com/pantsbuild/pants/discussions/18235
+        run: |
+          npm run generate-reference-all
+
+          if ! git diff --quiet ; then
+            echo "::group::Full diff"
+            git diff
+            echo "::endgroup::"
+
+            echo 'Changes to reference found, please regenerate with `npm run generate-reference-all` or `npm run generate-reference <specific directory>`'
+            exit 1
+          fi
+
       - name: Build
         run: npm run build
         env:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format-all": "prettier --write .",
     "format": "prettier --write",
     "check-formatting": "prettier --check .",
-    "generate-reference": "node reference_codegen/generate.js"
+    "generate-reference": "node reference_codegen/generate.js",
+    "generate-reference-all": "for d in docs versioned_docs/*; do npm run generate-reference $d; done"
   },
   "dependencies": {
     "@docusaurus/core": "^3.0.0",


### PR DESCRIPTION
This does a basic version of validating that the checked-in reference docs are valid, i.e. regenerating them gives the same result. It does this by just running the generation and checking that there's no changes.

This ensures that we don't, for instance, make a change to the templates and then forget to regenerate everything.