### PR TITLE
Run prettier on reference files as they are generated

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format-all": "prettier --write .",
     "format": "prettier --write",
     "check-formatting": "prettier --check .",
-    "generate-reference": "node reference_codegen/generate.js"
+    "generate-reference": "node reference_codegen/generate.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.0.0",

--- a/reference_codegen/generate.mjs
+++ b/reference_codegen/generate.mjs
@@ -3,6 +3,7 @@ import fs from "fs";
 import fsPromises from "fs/promises";
 import path from "path";
 import he from "he";
+import prettier from "prettier";
 
 // Load the relevant data
 const reference_dir = path.join(process.argv[2], "reference");
@@ -15,8 +16,14 @@ function pathify(file) {
   return path.join(reference_dir, file);
 }
 
+const prettierConfig = JSON.parse(fs.readFileSync(".prettierrc"));
 async function writeFile(file, contents) {
-  await fsPromises.writeFile(pathify(file), contents);
+  const parser = path.extname(file).slice(1);
+  const formatted = await prettier.format(contents, {
+    ...prettierConfig,
+    parser,
+  });
+  await fsPromises.writeFile(pathify(file), formatted);
 }
 
 function ensureEmptyDirectory(name) {

--- a/reference_codegen/generate.mjs
+++ b/reference_codegen/generate.mjs
@@ -221,13 +221,30 @@ await Promise.all(
 // `_category_.json` files
 await writeFile(
   "goals/_category_.json",
-  '{\n  "label": "Goals",\n  "link": {\n    "type": "generated-index",\n    "slug": "/reference/goals",\n    "title": "Goals"\n  }\n}\n'
+  JSON.stringify({
+    label: "Goals",
+    link: { type: "generated-index", slug: "/reference/goals", title: "Goals" },
+  })
 );
 await writeFile(
   "subsystems/_category_.json",
-  '{\n  "label": "Subsystems",\n  "link": {\n    "type": "generated-index",\n    "slug": "/reference/subsystems",\n    "title": "Subsystems"\n  }\n}\n'
+  JSON.stringify({
+    label: "Subsystems",
+    link: {
+      type: "generated-index",
+      slug: "/reference/subsystems",
+      title: "Subsystems",
+    },
+  })
 );
 await writeFile(
   "targets/_category_.json",
-  '{\n  "label": "Targets",\n  "link": {\n    "type": "generated-index",\n    "slug": "/reference/targets",\n    "title": "Targets"\n  }\n}\n'
+  JSON.stringify({
+    label: "Targets",
+    link: {
+      type: "generated-index",
+      slug: "/reference/targets",
+      title: "Targets",
+    },
+  })
 );

--- a/reference_codegen/generate.mjs
+++ b/reference_codegen/generate.mjs
@@ -1,7 +1,8 @@
-const Mustache = require("mustache");
-const fs = require("fs");
-const path = require("path");
-const he = require("he");
+import Mustache from "mustache";
+import fs from "fs";
+import fsPromises from "fs/promises";
+import path from "path";
+import he from "he";
 
 const reference_dir = path.join(process.argv[2], "reference");
 const helpAll = JSON.parse(

--- a/reference_codegen/generate.mjs
+++ b/reference_codegen/generate.mjs
@@ -185,15 +185,14 @@ Object.entries(helpAll.name_to_target_type_info).forEach(([name, info]) => {
   ensureEmptyDirectory(name)
 );
 
-// Global Options
-await writeFile(
-  "global-options.mdx",
-  renderSubsystemTemplate(helpAll["scope_to_help_info"][""], helpAll)
-);
-
-// Subsystems
-await Promise.all(
-  Object.entries(helpAll.scope_to_help_info).map(async ([scope, info]) => {
+await Promise.all([
+  // Global Options
+  writeFile(
+    "global-options.mdx",
+    renderSubsystemTemplate(helpAll["scope_to_help_info"][""], helpAll)
+  ),
+  // Subsystems
+  ...Object.entries(helpAll.scope_to_help_info).map(async ([scope, info]) => {
     if (scope === "") return;
 
     info.description = convertDescription(info.description);
@@ -202,49 +201,52 @@ await Promise.all(
       path.join(parent, `${info.scope}.mdx`),
       renderSubsystemTemplate(info, helpAll)
     );
-  })
-);
+  }),
 
-// Targets
-await Promise.all(
-  Object.entries(helpAll.name_to_target_type_info).map(async ([name, info]) => {
-    if (info.alias.startsWith("_")) return;
+  // Targets
+  ...Object.entries(helpAll.name_to_target_type_info).map(
+    async ([name, info]) => {
+      if (info.alias.startsWith("_")) return;
 
-    info.description = convertDescription(info.description);
-    await writeFile(
-      path.join("targets", `${info.alias}.mdx`),
-      renderTargetTemplate(info)
-    );
-  })
-);
-
-// `_category_.json` files
-await writeFile(
-  "goals/_category_.json",
-  JSON.stringify({
-    label: "Goals",
-    link: { type: "generated-index", slug: "/reference/goals", title: "Goals" },
-  })
-);
-await writeFile(
-  "subsystems/_category_.json",
-  JSON.stringify({
-    label: "Subsystems",
-    link: {
-      type: "generated-index",
-      slug: "/reference/subsystems",
-      title: "Subsystems",
-    },
-  })
-);
-await writeFile(
-  "targets/_category_.json",
-  JSON.stringify({
-    label: "Targets",
-    link: {
-      type: "generated-index",
-      slug: "/reference/targets",
-      title: "Targets",
-    },
-  })
-);
+      info.description = convertDescription(info.description);
+      await writeFile(
+        path.join("targets", `${info.alias}.mdx`),
+        renderTargetTemplate(info)
+      );
+    }
+  ),
+  // `_category_.json` files
+  writeFile(
+    "goals/_category_.json",
+    JSON.stringify({
+      label: "Goals",
+      link: {
+        type: "generated-index",
+        slug: "/reference/goals",
+        title: "Goals",
+      },
+    })
+  ),
+  writeFile(
+    "subsystems/_category_.json",
+    JSON.stringify({
+      label: "Subsystems",
+      link: {
+        type: "generated-index",
+        slug: "/reference/subsystems",
+        title: "Subsystems",
+      },
+    })
+  ),
+  writeFile(
+    "targets/_category_.json",
+    JSON.stringify({
+      label: "Targets",
+      link: {
+        type: "generated-index",
+        slug: "/reference/targets",
+        title: "Targets",
+      },
+    })
+  ),
+]);


### PR DESCRIPTION
This does a bunch of leg work to have the reference files be reformatted (with prettier) as they are written.  This makes the generation notably slower (slightly less than 1s -> slightly less than 4s on my machine), but saves from having to remember to run the formatting separately... which takes just as long as the extra time anyway.

This requires a few steps, broken across commits in a useful way (with some not-strictly-necessary changes), because prettier only has an async API. This seems to require running as an `.mjs` ("module") rather than `.js` to be able to use `await` at the top level.

After getting to using async + prettier, this then makes a few changes that this allows:

- a neater way to write the JSON files
- writing all files concurrently with `Promise.all` (writing the targets and subsystems concurrently takes the time from ~4.4s -> ~3.8s, doing the others concurrently makes no difference, but makes the code look uniform).

See also: https://github.com/pantsbuild/pantsbuild.org/pull/50#discussion_r1441051606
