### PR TITLE
Redirect `#code...code` fragments

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,6 +44,7 @@ const config = {
   onBrokenLinks: isDev ? "warn" : "warn",
   onBrokenMarkdownLinks: isDev ? "warn" : "warn",
 
+  clientModules: ["./src/js/redirectCodeFragment.js"],
   presets: [
     [
       "@docusaurus/preset-classic",

--- a/src/js/redirectCodeFragment.js
+++ b/src/js/redirectCodeFragment.js
@@ -5,5 +5,4 @@ export function onRouteUpdate({ location, previousLocation }) {
       window.location.replace(location.pathname + `#${matches[1]}`);
     }
   }
-  console.log(location);
 }

--- a/src/js/redirectCodeFragment.js
+++ b/src/js/redirectCodeFragment.js
@@ -1,0 +1,9 @@
+export function onRouteUpdate({ location, previousLocation }) {
+  if (location.hash && location.pathname.includes("/reference/")) {
+    const matches = /^#code(.+)code$/.exec(location.hash);
+    if (matches) {
+      window.location.replace(location.pathname + `#${matches[1]}`);
+    }
+  }
+  console.log(location);
+}

--- a/src/js/redirectCodeFragment.js
+++ b/src/js/redirectCodeFragment.js
@@ -1,4 +1,8 @@
 export function onRouteUpdate({ location, previousLocation }) {
+  // NB: Redirect fragments on reference pages if they look like `code{id}code`.
+  //  This only exists because the old readme.com docs used `<code>{id}</code>` in the header
+  //  and readme.com turned that into `id="code{id}code"`. So to continue to support those links,
+  //  we redirect.
   if (location.hash && location.pathname.includes("/reference/")) {
     const matches = /^#code(.+)code$/.exec(location.hash);
     if (matches) {


### PR DESCRIPTION
As an alternative to https://github.com/pantsbuild/pantsbuild.org/pull/55 and to fix #6, and pulled from option 4 of https://github.com/pantsbuild/pantsbuild.org/issues/6#issuecomment-1872622556, add a little JS to the React router that redirects `#code...code` fragments on reference pages.

Tested locally (`npm start`), and verified the "back" button doesn't go back to the `code` fragment URL but rather the URL before that.