### PR TITLE
Change `editURL` to a function

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -101,7 +101,12 @@ const config = {
                 }, {})),
           },
           remarkPlugins: [captionedCode],
-          editUrl: "https://github.com/pantsbuild/pantsbuild.org/edit/main/",
+          editUrl: ({ docPath }) => {
+            if (docPath.startsWith("reference/")) {
+              return undefined;
+            }
+            return `https://github.com/pantsbuild/pants/edit/main/docs/${docPath}`;
+          },
         },
         blog: includeBlog && {
           showReadingTime: true,


### PR DESCRIPTION
This change does 2 things (both of which fixes #https://github.com/pantsbuild/pantsbuild.org/issues/78)

- Removes edit URL on reference docs
- Changes the URL on the docs docs to `main` branch on the `pants` repo
  - NB This change is nonsensical until after the switchover