### PR TITLE
Ensure buildroot substitution is correct

### DIFF
--- a/reference_codegen/generate.mjs
+++ b/reference_codegen/generate.mjs
@@ -153,8 +153,8 @@ function convertDescription(val) {
 let buildroot = "";
 let cachedir = "";
 helpAll.scope_to_help_info[""].advanced.forEach((option) => {
-  if (option.config_key === "pants_workdir") {
-    buildroot = option.default.split("/").slice(0, -2).join("/");
+  if (option.config_key === "pants_distdir") {
+    buildroot = option.default.split("/").slice(0, -1).join("/");
   }
   if (option.config_key === "local_store_dir") {
     cachedir = option.default.split("/").slice(0, -2).join("/");

--- a/versioned_docs/version-2.0/reference/global-options.mdx
+++ b/versioned_docs/version-2.0/reference/global-options.mdx
@@ -259,7 +259,7 @@ Unused. Will be deprecated in 2.1.0.
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -283,7 +283,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-supportdir=<dir>`}
   env_repr='PANTS_SUPPORTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/build-support`}
+  default_repr={`<buildroot>/build-support`}
 >
 
 Unused. Will be deprecated in 2.1.0.
@@ -295,7 +295,7 @@ Unused. Will be deprecated in 2.1.0.
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -319,7 +319,7 @@ Whether to write binaries to the pre-2.0 paths under distdir. These legacy paths
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -331,7 +331,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -559,7 +559,7 @@ Directory to use for named global caches for tools and processes with trusted, c
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.

--- a/versioned_docs/version-2.1/reference/global-options.mdx
+++ b/versioned_docs/version-2.1/reference/global-options.mdx
@@ -259,7 +259,7 @@ Unused. Will be deprecated in 2.2.0.
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -283,7 +283,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-supportdir=<dir>`}
   env_repr='PANTS_SUPPORTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/build-support`}
+  default_repr={`<buildroot>/build-support`}
 >
 
 Unused. Will be deprecated in 2.2.0.
@@ -295,7 +295,7 @@ Unused. Will be deprecated in 2.2.0.
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -307,7 +307,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -319,7 +319,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -547,7 +547,7 @@ Directory to use for named global caches for tools and processes with trusted, c
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.

--- a/versioned_docs/version-2.10/reference/global-options.mdx
+++ b/versioned_docs/version-2.10/reference/global-options.mdx
@@ -337,7 +337,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -361,7 +361,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -373,7 +373,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -385,7 +385,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -683,7 +683,7 @@ The path may be absolute or relative. If the directory is within the build root,
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing.

--- a/versioned_docs/version-2.11/reference/global-options.mdx
+++ b/versioned_docs/version-2.11/reference/global-options.mdx
@@ -337,7 +337,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -361,7 +361,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -373,7 +373,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -385,7 +385,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -683,7 +683,7 @@ The path may be absolute or relative. If the directory is within the build root,
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing.

--- a/versioned_docs/version-2.12/reference/global-options.mdx
+++ b/versioned_docs/version-2.12/reference/global-options.mdx
@@ -337,7 +337,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -361,7 +361,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -373,7 +373,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -385,7 +385,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -683,7 +683,7 @@ The path may be absolute or relative. If the directory is within the build root,
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing.

--- a/versioned_docs/version-2.13/reference/global-options.mdx
+++ b/versioned_docs/version-2.13/reference/global-options.mdx
@@ -376,7 +376,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -400,7 +400,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -412,7 +412,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -424,7 +424,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.

--- a/versioned_docs/version-2.14/reference/global-options.mdx
+++ b/versioned_docs/version-2.14/reference/global-options.mdx
@@ -342,7 +342,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -366,7 +366,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -378,7 +378,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -390,7 +390,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.

--- a/versioned_docs/version-2.15/reference/global-options.mdx
+++ b/versioned_docs/version-2.15/reference/global-options.mdx
@@ -340,7 +340,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -364,7 +364,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `pants package`, to this dir.
@@ -376,7 +376,7 @@ Write end products, such as the results of `pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -388,7 +388,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.

--- a/versioned_docs/version-2.16/reference/global-options.mdx
+++ b/versioned_docs/version-2.16/reference/global-options.mdx
@@ -340,7 +340,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -364,7 +364,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `pants package`, to this dir.
@@ -376,7 +376,7 @@ Write end products, such as the results of `pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -388,7 +388,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.

--- a/versioned_docs/version-2.17/reference/global-options.mdx
+++ b/versioned_docs/version-2.17/reference/global-options.mdx
@@ -340,7 +340,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -364,7 +364,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `pants package`, to this dir.
@@ -376,7 +376,7 @@ Write end products, such as the results of `pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -388,7 +388,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.

--- a/versioned_docs/version-2.18/reference/global-options.mdx
+++ b/versioned_docs/version-2.18/reference/global-options.mdx
@@ -340,7 +340,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -364,7 +364,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `pants package`, to this dir.
@@ -376,7 +376,7 @@ Write end products, such as the results of `pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -388,7 +388,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.

--- a/versioned_docs/version-2.2/reference/global-options.mdx
+++ b/versioned_docs/version-2.2/reference/global-options.mdx
@@ -235,7 +235,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -259,7 +259,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-supportdir=<dir>`}
   env_repr='PANTS_SUPPORTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/build-support`}
+  default_repr={`<buildroot>/build-support`}
 >
 
 Unused. Will be deprecated in 2.2.0.
@@ -271,7 +271,7 @@ Unused. Will be deprecated in 2.2.0.
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -283,7 +283,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -295,7 +295,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -535,7 +535,7 @@ Directory to use for named global caches for tools and processes with trusted, c
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.

--- a/versioned_docs/version-2.3/reference/global-options.mdx
+++ b/versioned_docs/version-2.3/reference/global-options.mdx
@@ -223,7 +223,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -247,7 +247,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-supportdir=<dir>`}
   env_repr='PANTS_SUPPORTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/build-support`}
+  default_repr={`<buildroot>/build-support`}
 >
 
 Unused. Will be deprecated in 2.2.0.
@@ -259,7 +259,7 @@ Unused. Will be deprecated in 2.2.0.
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -271,7 +271,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -283,7 +283,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -535,7 +535,7 @@ Directory to use for named global caches for tools and processes with trusted, c
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.

--- a/versioned_docs/version-2.4/reference/global-options.mdx
+++ b/versioned_docs/version-2.4/reference/global-options.mdx
@@ -223,7 +223,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -247,7 +247,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-supportdir=<dir>`}
   env_repr='PANTS_SUPPORTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/build-support`}
+  default_repr={`<buildroot>/build-support`}
 >
 
 Unused. Will be deprecated in 2.2.0.
@@ -259,7 +259,7 @@ Unused. Will be deprecated in 2.2.0.
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -271,7 +271,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -283,7 +283,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -595,7 +595,7 @@ Directory to use for named global caches for tools and processes with trusted, c
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.

--- a/versioned_docs/version-2.5/reference/global-options.mdx
+++ b/versioned_docs/version-2.5/reference/global-options.mdx
@@ -230,7 +230,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -254,7 +254,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-supportdir=<dir>`}
   env_repr='PANTS_SUPPORTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/build-support`}
+  default_repr={`<buildroot>/build-support`}
 >
 
 Unused. Will be deprecated in 2.2.0.
@@ -266,7 +266,7 @@ Unused. Will be deprecated in 2.2.0.
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -278,7 +278,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -290,7 +290,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -612,7 +612,7 @@ The path may be absolute or relative. If the directory is within the build root,
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing.

--- a/versioned_docs/version-2.6/reference/global-options.mdx
+++ b/versioned_docs/version-2.6/reference/global-options.mdx
@@ -232,7 +232,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -256,7 +256,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-supportdir=<dir>`}
   env_repr='PANTS_SUPPORTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/build-support`}
+  default_repr={`<buildroot>/build-support`}
 >
 
 Unused. Will be deprecated in 2.2.0.
@@ -268,7 +268,7 @@ Unused. Will be deprecated in 2.2.0.
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -280,7 +280,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -292,7 +292,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -614,7 +614,7 @@ The path may be absolute or relative. If the directory is within the build root,
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing.

--- a/versioned_docs/version-2.7/reference/global-options.mdx
+++ b/versioned_docs/version-2.7/reference/global-options.mdx
@@ -234,7 +234,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -258,7 +258,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-supportdir=<dir>`}
   env_repr='PANTS_SUPPORTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/build-support`}
+  default_repr={`<buildroot>/build-support`}
   removal_version='2.9.0.dev0'
   removal_hint={'Unused: this option has no necessary equivalent in v2.'}
 >
@@ -272,7 +272,7 @@ Used only for templating in `pants.toml`.
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -284,7 +284,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -296,7 +296,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -618,7 +618,7 @@ The path may be absolute or relative. If the directory is within the build root,
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing.

--- a/versioned_docs/version-2.8/reference/global-options.mdx
+++ b/versioned_docs/version-2.8/reference/global-options.mdx
@@ -234,7 +234,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -258,7 +258,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -270,7 +270,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -282,7 +282,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -604,7 +604,7 @@ The path may be absolute or relative. If the directory is within the build root,
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing.
@@ -1143,7 +1143,7 @@ True if stats recording should be allowed to complete asynchronously when `pants
 <Option
   cli_repr={`--pants-supportdir=<dir>`}
   env_repr='PANTS_SUPPORTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/build-support`}
+  default_repr={`<buildroot>/build-support`}
   removal_version='2.9.0.dev0'
   removal_hint={'Unused: this option has no necessary equivalent in v2.'}
 >

--- a/versioned_docs/version-2.9/reference/global-options.mdx
+++ b/versioned_docs/version-2.9/reference/global-options.mdx
@@ -324,7 +324,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
 <Option
   cli_repr={`--pants-workdir=<dir>`}
   env_repr='PANTS_WORKDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pants.d`}
+  default_repr={`<buildroot>/.pants.d`}
 >
 
 Write intermediate logs and output files to this dir.
@@ -348,7 +348,7 @@ When set, a base directory in which to store `--pants-workdir` contents. If this
 <Option
   cli_repr={`--pants-distdir=<dir>`}
   env_repr='PANTS_DISTDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/dist`}
+  default_repr={`<buildroot>/dist`}
 >
 
 Write end products, such as the results of `./pants package`, to this dir.
@@ -360,7 +360,7 @@ Write end products, such as the results of `./pants package`, to this dir.
 <Option
   cli_repr={`--pants-subprocessdir=<str>`}
   env_repr='PANTS_SUBPROCESSDIR'
-  default_repr={`<buildroot>/tmp.MpwSc5OGVo/.pids`}
+  default_repr={`<buildroot>/.pids`}
 >
 
 The directory to use for tracking subprocess metadata. This should live outside of the dir used by `pants_workdir` to allow for tracking subprocesses that outlive the workdir data.
@@ -372,7 +372,7 @@ The directory to use for tracking subprocess metadata. This should live outside 
 <Option
   cli_repr={`--pants-config-files="['<str>', '<str>', ...]"`}
   env_repr='PANTS_CONFIG_FILES'
-  default_repr={`[\n  "<buildroot>/tmp.MpwSc5OGVo/pants.toml"\n]`}
+  default_repr={`[\n  "<buildroot>/pants.toml"\n]`}
 >
 
 Paths to Pants config files. This may only be set through the environment variable `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will be ignored if in a config file like `pants.toml`.
@@ -670,7 +670,7 @@ The path may be absolute or relative. If the directory is within the build root,
 <Option
   cli_repr={`--local-execution-root-dir=<str>`}
   env_repr='PANTS_LOCAL_EXECUTION_ROOT_DIR'
-  default_repr={`<buildroot>`}
+  default_repr={`/tmp`}
 >
 
 Directory to use for local process execution sandboxing.


### PR DESCRIPTION
In Pants 2.20, the workdir changed to `<buildroot>/pants.d/workdir`, so switch to using `pants_distdir` option for `buildroot` substitution.