### PR TITLE
Add `tabBlocks` remark plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -73,7 +73,7 @@ const config = {
         blog: includeBlog && {
           showReadingTime: true,
           editUrl: "https://github.com/pantsbuild/pantsbuild.org/edit/main/",
-          remarkPlugins: [captionedCode],
+          remarkPlugins: [captionedCode, tabBlocks],
           blogSidebarTitle: "All posts",
           blogSidebarCount: "ALL",
           postsPerPage: "ALL",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,7 @@
 import versions from "./versions.json";
 import redirects from "./old_site_redirects.js";
 import captionedCode from "./src/remark/captioned-code.js";
+import tabBlocks from "docusaurus-remark-plugin-tab-blocks";
 
 import { themes as prismThemes } from "prism-react-renderer";
 
@@ -299,7 +300,7 @@ const config = {
                 return acc;
               }, {})),
         },
-        remarkPlugins: [captionedCode],
+        remarkPlugins: [captionedCode, tabBlocks],
         editUrl: ({ docPath }) => {
           if (docPath.startsWith("reference/")) {
             return undefined;


### PR DESCRIPTION
This seems to be an oversight, as we are using the code metadata for these tabs.

Fixes https://github.com/pantsbuild/pantsbuild.org/issues/98