### PR TITLE
Sync from `docs/docs` on the Pants repo

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -87,7 +87,7 @@ jobs:
         working-directory: pantsbuild.org
 
       # Sync the docs repo
-      - run: cp -r pants/docs "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
+      - run: cp -r pants/docs/docs "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
       - run: npm run format -- "${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
         working-directory: pantsbuild.org
 


### PR DESCRIPTION
I plan on putting docs at `docs/docs` so we can put extra stuff in `docs/` (like a README)