### PR TITLE
Ignore docs & versioned_docs in prettier

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -88,8 +88,6 @@ jobs:
 
       # Sync the docs repo
       - run: cp -r pants/docs/docs "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
-      - run: npm run format -- "${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
-        working-directory: pantsbuild.org
 
       # Commit and create a PR
       - name: Commit changes

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# the synced & auto-generated files shouldn't be changed
+docs
+versioned_docs


### PR DESCRIPTION
This marks the synced/auto-generated directories of `docs/` and `versioned_docs/` as not being reformatted by prettier:

- for the synced prose docs, this repo isn't the source of truth: we should be just trusting whatever the pants repo gives us (and the pants repo could/should be prettier-ising them itself)
- for the generated docs, we should just trust whatever comes out of the generator (which happens to already be prettier'd)

Thoughts?
