### PR TITLE
Bump headers of docs with h1 headers

### DIFF
--- a/docs/docs/contributions/development/internal-architecture.mdx
+++ b/docs/docs/contributions/development/internal-architecture.mdx
@@ -5,9 +5,9 @@
 
 ---
 
-# Rule Graph Construction
+## Rule Graph Construction
 
-## Overview
+### Overview
 
 Build logic in [Pants](https://www.pantsbuild.org/) is declared using collections of `@rules` with recursively memoized and invalidated results. This framework (known as Pants' "Engine") has similar goals to Bazel's [Skyframe](https://bazel.build/designs/skyframe.html) and the [Salsa](https://github.com/salsa-rs/salsa) framework: users define logic using a particular API, and the framework manages tracking the dependencies between nodes in a runtime graph.
 
@@ -15,11 +15,11 @@ In order to maximize the amount of work that can be reused at runtime, Pants sta
 
 Concepts used in compilers, including live variable analysis and monomorphization, can also be useful in rule graph construction to minimize rule identities and pre-decide which versions of their dependencies they will use.
 
-## Concepts
+### Concepts
 
 A successfully constructed `RuleGraph` contains a graph where nodes have one of three types, `Rule`s, `Query`s, and `Param`s, which map fairly closely to what a Pants `@rule` author consumes. The edges between nodes represent dependencies: `Query`s are always roots of the graph, `Param`s are always leaves, and `Rule`s represent the end user logic making up all of the internal nodes of the graph.
 
-### Rules
+#### Rules
 
 A `Rule` is a function or coroutine with all of its inputs declared as part of its type signature. The end user type signature is made up of:
 
@@ -31,13 +31,13 @@ In the `RuleGraph`, these are encoded in a [Rule](https://github.com/pantsbuild/
 
 `Rule`s never refer to one another by name (i.e., they do not call one another by name): instead, their signature declares their requirements in terms of input/output types, and rule graph construction decides which potential dependencies will provide those requirements.
 
-### Queries
+#### Queries
 
 The roots/entrypoints of a `RuleGraph` are `Query`s, which should correspond one-to-one to external callsites that use the engine to request that values are computed. A `Query` has an output type, and a series of input types: `Query(output_type, (*input_types))`.
 
 If a user makes a request to the engine that does not have a corresponding `Query` declared, the engine fails rather than attempting to dynamically determine which `Rules` to use to answer the `Query`: how a `RuleGraph` is constructed should show why that is the case.
 
-### Params
+#### Params
 
 `Params` are typed, comparable (`eq`/`hash`) values that represent both the inputs to `Rules`, and the building block of the runtime memoization key for a `Rule`. The set of `Params` (unique by type) that are consumed to create a `Rule`'s inputs (plus the `Rule`'s own identity) make up the memoization key for a runtime instance of the `Rule`.
 
@@ -47,7 +47,7 @@ The `Param`s that are available to a `Rule` are made available by the `Rule`'s d
 
 `Params` flow down the graph from `Query`s and the provided `Param`s of `Get`s: their presence does not need to be re-declared at each intermediate callsite. When a `Rule` consumes a `Param` as a positional argument, that `Param` will no longer be available to that `Rule`'s dependencies (but it might still be present in other subgraphs adjacent to that `Rule`).
 
-## Goals
+### Goals
 
 The goals of `RuleGraph` construction are:
 
@@ -61,7 +61,7 @@ If either of the goals were removed, `RuleGraph` construction might be more stra
 
 But both of the goals are important because together they allow for an API that is easy to write `Rule`s for, with minimal boilerplate required to get the inputs needed for a `Rule` to compute a value, and minimal invalidation. Because the identity of a `Rule` is computed from its transitive input `Param`s rather than from its positional arguments, `Rule`s can accept arbitrarily-many large input values (which don't need to implement hash) with no impact on its memoization hit rate.
 
-## Constraints
+### Constraints
 
 There are a few constraints that decide which `Rule`s are able to provide dependencies for one another:
 
@@ -71,7 +71,7 @@ There are a few constraints that decide which `Rule`s are able to provide depend
 - `provided_params` - When deciding whether one `Rule` can use another `Rule` to provide the output type of a `Get`, a constraint is applied that the candidate depedency must (transitively) consume the `Param` that is provided by the `Get`.
   - For example: if a `Rule` `z` has a `Get(A, B)`, only `Rule`s that compute an `A` and (transitively) consume a `B` are eligible to be used. This also means that a `Param` `A` which is already in scope for `Rule` `z` is not eligible to be used, because it would trivially not consume `B`.
 
-## Implementation
+### Implementation
 
 As of [3a188a1e06](https://github.com/pantsbuild/pants/blob/3a188a1e06d8c27ff86d8c311ff1b2bdea0d39ff/src/rust/engine/rule_graph/src/builder.rs#L202-L219), we construct a `RuleGraph` using a combination of data flow analysis and some homegrown (and likely problematic: see the "Issue Overview") node splitting on the call graph of `Rule`s.
 

--- a/docs/docs/helm/index.mdx
+++ b/docs/docs/helm/index.mdx
@@ -11,7 +11,7 @@ Pants has good support for the most common operations for managing Helm charts s
 Please share feedback for what you need to use Pants with your Helm charts by either [opening a GitHub issue](https://github.com/pantsbuild/pants/issues/new/choose) or [joining our Slack](/community/getting-help)!
 :::
 
-# Initial setup
+## Initial setup
 
 First, activate the relevant backend in `pants.toml`:
 
@@ -40,7 +40,7 @@ name: bar
 version: 0.1.0
 ```
 
-## Adding `helm_chart` targets
+### Adding `helm_chart` targets
 
 Helm charts are identified by the presence of a `Chart.yaml` or `Chart.yml` file, which contains relevant metadata about the chart like its name, version, dependencies, etc. To get started quickly you can create a simple `Chart.yaml` file in your sources folder:
 
@@ -65,11 +65,11 @@ Created src/helm/example/BUILD:
 
 If your workspace contains any Helm unit tests (under a `tests` folder), Pants will also idenfity them and create `helm_unittest_tests` targets for them. Additionally, if your unit tests also have snapshots (under a `tests/__snapshot__` folder), `tailor` will identify those files as test snapshots and will create `resources` targets for them. See "Snapshot testing" below for more info.
 
-## Basic operations
+### Basic operations
 
 The given setup is enough to now do some common operations on our Helm chart source code.
 
-### Linting
+#### Linting
 
 The Helm backend has an implementation of the Pants' `lint` goal which hooks it with the `helm lint` command:
 
@@ -100,7 +100,7 @@ Likewise, in a similar way you could enable strict linting globally and then cho
 
 You can set the field `skip_lint=True` on each `helm_chart` target to avoid linting it.
 
-### Package
+#### Package
 
 Packing helm charts is supported out of the box via the Pants' `package` goal. The final package will be saved as a `.tgz` file under the `dist` folder at your source root.
 
@@ -113,7 +113,7 @@ Built Helm chart artifact: testprojects.src.helm.example/example/example-0.2.0.t
 
 The final output folder can customised using the `output_path` field in the `helm_chart` target. Run `pants help helm_chart` for more information.
 
-### Helm chart version
+#### Helm chart version
 
 Helm charts are versioned artifacts with the value of the `version` field in `Chart.yaml` determining the actual version of the chart. Pants needs to know the version of a first party chart to be able to build packages and correctly establish the dependencies among them. By default, Pants will use the value in `Chart.yaml` as the given version of a chart but it also supports overriding that value via the `version` field in the `helm_chart` target.
 
@@ -153,7 +153,7 @@ helm_chart(version=env('HELM_CHART_VERSION'))
 
 Now the version value for this chart will be what has been set as the value of the environment variable `HELM_CHART_VERSION`.
 
-# Helm Unit tests
+## Helm Unit tests
 
 The Helm backend supports running Helm unit tests via the [Helm `unittest` plugin](https://github.com/quintush/helm-unittest). To run unit tests follow the instructions on how to use that plugin and then create a `BUILD` file in the same folder where your tests live with the following target:
 
@@ -201,7 +201,7 @@ pants test ::
 ✓ testprojects/src/helm/example/tests/env-configmap_test.yaml succeeded in 0.75s.
 ```
 
-### Feeding additional files to unit tests
+#### Feeding additional files to unit tests
 
 In some cases we may want our tests to have access to additional files which are not part of the chart. This can be achieved by setting a dependency between our unit test targets and a `resources` target as follows:
 
@@ -304,7 +304,7 @@ not affected by the source roots setting. When using `relocated_files`, the file
 to the value set in the `dest` field.
 :::
 
-### Snapshot testing
+#### Snapshot testing
 
 Unit test snapshots are supported by Pants by wrapping the snapshots in resources targets, as shown in the previous section. Snapshot resources will be automatically inferred as dependencies of the tests where they reside, so there is no need to add a explicit `dependencies` relationship in your `helm_unittest_tests` targets.
 
@@ -318,7 +318,7 @@ This will generate test snapshots for tests that require them, with out-of-date 
 
 If new `__snapshot__` folders are created after running the `generate-snapshots` target, we recommend running the `tailor` goal again so that Pants can detect these new folders and create `resources` targets as appropriate.
 
-### Timeouts
+#### Timeouts
 
 Pants can cancel tests that take too long, which is useful to prevent tests from hanging indefinitely.
 
@@ -352,13 +352,13 @@ If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will 
 
 Use the option `pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
-# Publishing Helm charts
+## Publishing Helm charts
 
 Pants only supports publishing Helm charts to OCI registries, a feature that was made generally available in Helm 3.8.
 
 The publishing is done with Pants' `publish` goal but first you will need to tell Pants what are the possible destination registries where to upload your charts.
 
-## Configuring OCI registries
+### Configuring OCI registries
 
 In a similar way as the `docker_image` target, a `helm_chart` target takes an optional `registries` field whose value is a list of registry endpoints (prefixed by the `oci://` protocol):
 
@@ -406,7 +406,7 @@ helm_chart(
 )
 ```
 
-## Setting a repository name
+### Setting a repository name
 
 When publishing charts into an OCI registry, you most likely will be interested on separating them from other kind of OCI assets (i.e. container images). For doing so you can set a `repository` field in the `helm_chart` target so the chart artifact will be uploaded to the given path:
 
@@ -426,7 +426,7 @@ You can also set a default global repository in `pants.toml` as in the following
 default_registry_repository = "charts"
 ```
 
-# Managing Chart Dependencies
+## Managing Chart Dependencies
 
 Helm charts can depend on other charts, whether first-party charts defined in the same repo, or third-party charts published in a registry. Pants uses this dependency information to know when work needs to be re-run.
 
@@ -434,7 +434,7 @@ Helm charts can depend on other charts, whether first-party charts defined in th
 To benefit from Pants dependency management and inference in your Helm charts, you will need to use `apiVersion: v2` in your `Chart.yaml` file.
 :::
 
-## `Chart.yaml` dependencies
+### `Chart.yaml` dependencies
 
 Pants will automatically infer dependencies from the `Chart.yaml` file.
 
@@ -471,7 +471,7 @@ pants dependencies src/helm/bar
 src/helm/foo
 ```
 
-## Explicitly provided dependencies in `BUILD` files
+### Explicitly provided dependencies in `BUILD` files
 
 If you prefer, you can let your BUILD files be the "source of truth" for dependencies, instead of specifying them in `Chart.yaml`:
 
@@ -499,7 +499,7 @@ helm_chart(dependencies=["//src/helm/foo"])
 
 In this case, the `pants dependencies` command will show the same result and, in addition, Pants will modify its copy of `bar`'s `Chart.yaml` before using it, so that it includes `foo` in its dependency list. Note that Pants will not modify the original copy in your source tree, only the copy it uses in the sandboxed execution environment.
 
-## Third party chart artifacts
+### Third party chart artifacts
 
 Third party charts are provided to Pants using the `helm_artifact` target:
 

--- a/docs/docs/introduction/welcome-to-pants.mdx
+++ b/docs/docs/introduction/welcome-to-pants.mdx
@@ -5,11 +5,11 @@
 
 ---
 
-# What is Pants?
+## What is Pants?
 
 Pants is a fast, scalable, user-friendly build and developer workflow system for codebases of all sizes, including yours!
 
-# What does Pants do?
+## What does Pants do?
 
 Pants installs, orchestrates and runs dozens of standard underlying tools - compilers, code generators, dependency resolvers, test runners, linters, formatters, packagers, REPLs and more - composing them into a single stable, hermetic toolchain, and speeding up your workflows via caching and concurrency.
 
@@ -17,13 +17,13 @@ Pants is designed to be easy to adopt, use, and extend. It doesn't require you t
 
 Pants is currently focused on Python, Go, Java, Scala, Shell, and Docker, with more languages and frameworks coming soon. [The Pants community](/community/members) is friendly and helpful and welcomes involvement of anyone who is interested in creating modern software development tooling.
 
-# Who is Pants for?
+## Who is Pants for?
 
 Pants is useful for repos of all sizes, but is particularly valuable for those containing multiple distinct but interdependent pieces.
 
 Pants works well with (but does not require) a [_monorepo_ architecture](https://blog.pantsbuild.org/the-monorepo-approach-to-code-management/): a codebase containing multiple projects—often using multiple programming languages and frameworks—in a single unified repository. If you want to scale your codebase without breaking it up into multiple disconnected repos, with all the versioning and maintenance headaches that causes, Pants provides the tooling for you to do so effectively.
 
-# What are the main features of Pants?
+## What are the main features of Pants?
 
 Pants is designed for fast, consistent, ergonomic builds. Some noteworthy features include:
 
@@ -36,7 +36,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 - Extensibility and customizability via a plugin API
 - Code introspection features
 
-# Which languages and frameworks does Pants support?
+## Which languages and frameworks does Pants support?
 
 - Pants [ships](page:language-support) with support for [Python](../python/overview/index.mdx), [Go](../go/index.mdx), [Java](../java-and-scala/index.mdx), [Scala](../java-and-scala/index.mdx) and [Shell](../shell/index.mdx).
 - Pants supports a wide range of code generators (such as Thrift, Protobuf, Scrooge and Avro), linters and formatters, and it is easy to add support for new or custom ones
@@ -45,7 +45,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 We're listening to the community for which languages, frameworks and tools we should support next, so let us know about your needs by [opening an issue](https://github.com/pantsbuild/pants/issues/new/choose) on GitHub or [chatting with us](/community/members) about it on the community Slack!
 Pants was designed for extensibility, and we welcome [contributions](../contributions/index.mdx)!
 
-# How does Pants work?
+## How does Pants work?
 
 The core of Pants is its execution engine, which sequences and coordinates all the underlying work. The engine is written in Rust, for performance. The underlying work is performed by executing _rules_, which are typed Python 3 async coroutines for familiarity and simplicity.
 
@@ -53,17 +53,17 @@ The engine is designed so that fine-grained invalidation, concurrency, hermetici
 
 See [here](./how-does-pants-work.mdx) for more details about the Pants engine.
 
-# Is Pants similar to X?
+## Is Pants similar to X?
 
 Pants (v2) is a leap forward in the evolution of build systems, a category that runs from the venerable Make through Ant, Maven, Gradle and SBT, to Bazel, Please, Buck, Pants v1 and others.
 
 Its design leans on ideas and inspiration from these earlier tools, while optimizing not just for speed and correctness, but also for ease of adoption, ease of use and ease of extension, all for real-world use cases at a variety of teams.
 
-# Who uses Pants?
+## Who uses Pants?
 
 Pants is making engineering teams productive and happy at a range of companies and organizations. See a sample of them [here](page:who-uses-pants)!
 
-# Who develops Pants?
+## Who develops Pants?
 
 Pants is an open-source software project, developed at [github.com/pantsbuild/pants](https://github.com/pantsbuild/pants). Pants is released under the [Apache License 2.0](https://github.com/pantsbuild/pants/blob/master/LICENSE).
 

--- a/docs/docs/terraform/index.mdx
+++ b/docs/docs/terraform/index.mdx
@@ -11,7 +11,7 @@ Pants is currently building support for developing and deploying Terraform. Simp
 Please share feedback for what you need to use Pants with your Terraform modules and deployments by either [opening a GitHub issue](https://github.com/pantsbuild/pants/issues/new/choose) or [joining our Slack](/community/getting-help)!
 :::
 
-# Initial setup
+## Initial setup
 
 First, activate the relevant backend in `pants.toml`:
 
@@ -26,14 +26,14 @@ backend_packages = [
 
 The Terraform backend also needs Python to run Pants's analysers. The setting `[python].interpreter_constraints` will need to be set.
 
-## Adding Terraform targets
+### Adding Terraform targets
 
 The Terraform backend has 2 target types:
 
 - `terraform_module` for Terraform source code
 - `terraform_deployment` for deployments that can be deployed with the `experimental-deploy` goal
 
-### Modules
+#### Modules
 
 The `tailor` goal will automatically generate `terraform_module` targets. Run [`pants tailor ::`](../getting-started/initial-configuration.mdx#5-generate-build-files). For example:
 
@@ -43,7 +43,7 @@ Created src/terraform/root/BUILD:
   - Add terraform_module target root
 ```
 
-### Deployments
+#### Deployments
 
 `terraform_deployments` must be manually created. The deployment points to a `terraform_module` target as its `root_module` field. This module will be the "root" module that Terraform operations will be run on. You can reference vars files with the `var_files` field. You can have multiple deployments reference the same module:
 
@@ -53,7 +53,7 @@ terraform_deployment(name="prod", root_module=":root", var_files=["prod.tfvars"]
 terraform_deployment(name="test", root_module=":root", var_files=["test.tfvars"])
 ```
 
-### Lockfiles
+#### Lockfiles
 
 Automatic lockfile management is currently in progress. You can include lockfiles manually as a dependency:
 
@@ -62,9 +62,9 @@ terraform_deployment(name="prod", root_module=":root", dependencies=[":lockfile"
 file(name="lockfile", source=".terraform.lock.hcl")
 ```
 
-## Basic Operations
+### Basic Operations
 
-### Formatting
+#### Formatting
 
 Run `terraform fmt` as part of the `fix`, `fmt`, or `lint` goals.
 
@@ -75,7 +75,7 @@ pants fix ::
 ✓ terraform-fmt made no changes.
 ```
 
-### Validate
+#### Validate
 
 Run `terraform validate` as part of the `check` goal.
 
@@ -94,7 +94,7 @@ Success! The configuration is valid.
 terraform_module(skip_terraform_validate=True)
 ```
 
-### Deploying
+#### Deploying
 
 :::caution Terraform deployment support is in alpha stage
 Many options and features aren't supported yet.

--- a/docs/docs/using-pants/environments.mdx
+++ b/docs/docs/using-pants/environments.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Environments
+## Environments
 
 :::caution Environments are currently in `preview`, and have not yet stabilized.
 We'd love your feedback on how Environments could be most useful to you! Please refer to [the tracking issue](https://github.com/pantsbuild/pants/issues/17355) for known stabilization blockers.
@@ -17,7 +17,7 @@ By default, Pants will execute all sandboxed build work directly on localhost. B
 2. remotely via [remote execution](./remote-caching-&-execution/remote-execution.mdx)
 3. locally, but with a non-default set of environment variables and settings (such as when different platforms need different values, or when cross-building)
 
-## Defining environments
+### Defining environments
 
 Environments are defined using environment targets:
 
@@ -53,7 +53,7 @@ docker_environment(
 Environment targets are loaded before regular targets in a bootstrap phase, during which macros are unavailable. As such any required field values must be fully defined in the BUILD file without referencing any macros. For optional fields, the use of macros are still discouraged as it may or may not work and Pants makes no guarantees that it will not break in a future version if it were to currently work.
 :::
 
-### Environment-aware options
+#### Environment-aware options
 
 Environment targets have fields ([target](./key-concepts/targets-and-build-files.mdx) arguments) which correspond to [options](./key-concepts/options.mdx) which are marked "environment-aware". When an option is environment-aware, the value of the option that will be used in an environment can be overridden by setting the corresponding field value on the associated environment target. If an environment target does not set a value, it defaults to the value which is set globally via options values.
 
@@ -63,7 +63,7 @@ For example, the [`[python-bootstrap].search_path` option](../../reference/subsy
 Environments are a new concept: if you see an option value which should be marked environment-aware but isn't, please definitely [file an issue](https://github.com/pantsbuild/pants/issues/new/choose)!
 :::
 
-## Consuming environments
+### Consuming environments
 
 To declare which environment they should build with, many target types (but particularly "root" targets like tests or binaries) have an `environment=` field: for example, [`python_tests(environment=..)`](../../reference/targets/python_tests.mdx#environment).
 
@@ -78,7 +78,7 @@ Currently, there is no static validation that a target's environment is compatib
 As we gain more experience with how environments are used in the wild, it's possible that more static validation can be added: your feedback would be very welcome!
 :::
 
-### Setting the environment on many targets at once
+#### Setting the environment on many targets at once
 
 To use an environment everywhere in your repository (or only within a particular subdirectory, or with a particular target
 type), you can use the [`__defaults__` builtin](./key-concepts/targets-and-build-files.mdx#field-default-values). For example, to use an environment named `my_default_environment` globally by default, you would add the following to a `BUILD` file at the root of the repository:
@@ -89,7 +89,7 @@ __defaults__(all=dict(environment="my_default_environment"))
 
 ... and individual targets could override the default as needed.
 
-### Building one target in multiple environments
+#### Building one target in multiple environments
 
 If a target will always need to be built in multiple environments (rather than conditionally based on which user is building it: see the "Toggle use of an environment for some consumers" section), then you can use the [`parametrize` builtin](./key-concepts/targets-and-build-files.mdx#parametrizing-targets) for the `environment=` field. If you had two environments named `linux` and `macos`, that would look like:
 
@@ -100,7 +100,7 @@ pex_binary(
 )
 ```
 
-### Environment matching
+#### Environment matching
 
 A single environment name may end up referring to different environment targets on different physical machines, or with different global settings applied: this is known as environment "matching".
 
@@ -133,9 +133,9 @@ docker_environment(
 
 In future versions, environment targets will gain additional predicates to control whether they match (for example: `local_environment` will likely gain a predicate that looks for the [presence or value of an environment variable](https://github.com/pantsbuild/pants/issues/17107). But in the meantime, it's possible to override which environments are matched for particular use cases by overriding their configured names: see the "Toggle use of an environment" workflow below for an example.
 
-## Example workflows
+### Example workflows
 
-### Enabling remote execution globally
+#### Enabling remote execution globally
 
 `remote_environment` targets match unless the [`--remote-execution`](../../reference/global-options.mdx#remote_execution) option is disabled. So to cause a particular environment name to use remote execution whenever it is enabled, you could define environment targets which try remote execution first, and then fall back to local execution:
 
@@ -167,7 +167,7 @@ local = "//:local"
 The `2.15.x` series of Pants does not yet support ["speculating" remote execution](https://github.com/pantsbuild/pants/issues/8353) by racing it against another environment (usually local or docker). While we expect that this will be necessary to make remote execution a viable option for local execution on user's laptops (where network connections are less reliable), it is less critical for CI use-cases.
 :::
 
-### Use a `docker_environment` to build the inputs to a `docker_image`
+#### Use a `docker_environment` to build the inputs to a `docker_image`
 
 To build a `docker_image` target containing a `pex_binary` which uses native (i.e. compiled) dependencies on a `macOS` machine, you can configure the `pex_binary` to be built in a `docker_environment`.
 
@@ -206,7 +206,7 @@ Note that the Docker image used in your `docker_environment` does not need to ma
 This means that your `docker_environment` can include things like compilers or other tools relevant to your build, without needing to manually use multi-stage Docker builds.
 :::
 
-### Toggle use of an environment for some consumers
+#### Toggle use of an environment for some consumers
 
 As mentioned above in "Environment matching", environment targets "match" based on their field values and global options. But if two environment targets would be ambiguous in some cases, or if you'd otherwise like to control what a particular environment name means (in CI, for example), you can override an environment name via options.
 

--- a/docs/docs/using-pants/key-concepts/goals.mdx
+++ b/docs/docs/using-pants/key-concepts/goals.mdx
@@ -17,7 +17,7 @@ To see the current list of goals, run:
 
 You'll see more goals activated as you activate more [backends](./backends.mdx).
 
-# Running goals
+## Running goals
 
 For example:
 
@@ -48,7 +48,7 @@ Finally, Pants supports running goals in a `--loop`. In this mode, all goals spe
 
 Use `Ctrl+C` to exit the `--loop`.
 
-# Goal arguments
+## Goal arguments
 
 Most goals require arguments to know what to work on.
 
@@ -71,7 +71,7 @@ To ignore something, prefix the argument with `-`. For example, `pants test :: -
 See [Advanced target selection](../advanced-target-selection.mdx) for alternative techniques to specify which files/targets to run on.
 :::
 
-## Goal options
+### Goal options
 
 Many goals also have [options](./options.mdx) to change how they behave. Every option in Pants can be set via an environment variable, config file, and the command line.
 

--- a/docs/docs/using-pants/key-concepts/options.mdx
+++ b/docs/docs/using-pants/key-concepts/options.mdx
@@ -7,7 +7,7 @@ A deep dive into how options may be configured.
 
 ---
 
-# Option scopes
+## Option scopes
 
 Options are partitioned into named _scopes_.
 
@@ -15,7 +15,7 @@ Some systemwide options belong in the _global scope_. For example, the `--level`
 
 Other options belong to a _subsystem scope_. A _subsystem_ is simply a collection of related options, in a scope. For example, the `pytest` subsystem contains options related to [Python's test framework pytest](../../../reference/subsystems/pytest.mdx).
 
-# Setting options
+## Setting options
 
 Every option can be set in the following ways, in order of precedence:
 
@@ -27,7 +27,7 @@ If an option isn't set in one of these ways, it will take on a default value.
 
 You can inspect both the current value and the default value by using `pants help $scope` or `pants help-advanced $scope`, e.g. `pants help global`.
 
-## Command-line flags
+### Command-line flags
 
 Global options are set using an unqualified flag:
 
@@ -41,7 +41,7 @@ Subsystem options are set by providing the flag, with the name prefixed with the
 pants --source-root-patterns="['^ext']"
 ```
 
-## Environment variables
+### Environment variables
 
 Global options are set using the environment variable `PANTS_{OPTION_NAME}`:
 
@@ -58,7 +58,7 @@ PANTS_SOURCE_ROOT_PATTERNS="['^ext']" pants ...
 
 Note that the scope and option name are upper-cased, and any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `MULTIWORD_NAME`.
 
-## Config file entries
+### Config file entries
 
 Global options are set in the `GLOBAL` section of the config file:
 
@@ -76,7 +76,7 @@ root_patterns = ["/src/python"]
 
 Note that any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `multiword_name`.
 
-### Config file interpolation
+#### Config file interpolation
 
 A string value in a config file can contain placeholders of the form `%(key)s`, which will be replaced with a corresponding value. The `key` can be one of:
 
@@ -105,7 +105,7 @@ repo_host = "repo.%(domain)s"
 indexes.add = ["http://%(env.PY_REPO)s@%(repo_host)s/index
 ```
 
-# Option types
+## Option types
 
 Every option has a type, and any values you set must be of that type.
 
@@ -119,25 +119,25 @@ The option types are:
 
 A list-valued option may also declare a specific type for its members (e.g., a list of strings, or a list of integers).
 
-## String and integer values
+### String and integer values
 
 Standalone string and integer values are written without quotes. Any quotes will be considered part of the value, after shell escaping.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-intopt=42
 pants --scope-stropt=qux
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_INTOPT=42
 PANTS_SCOPE_STROPT=qux
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -145,11 +145,11 @@ intopt = 42
 stropt = "qux"
 ```
 
-## Boolean values
+### Boolean values
 
 Boolean values can be specified using the special strings `true` and `false`. When specifying them via command-line flags you can also use the `--boolopt/--no-boolopt` syntax.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-boolopt=true
@@ -157,24 +157,24 @@ pants --scope-boolopt
 pants --no-scope-boolopt
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_BOOLOPT=true
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
 boolopt = true
 ```
 
-## List values
+### List values
 
 List values are parsed as Python list literals, so you must quote string values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-listopt="['foo','bar']"
@@ -188,7 +188,7 @@ pants --scope-listopt=foo --scope-listopt=bar
 
 Appending will add to any values from lower-precedence sources, such as config files (`pants.toml`) and possibly Pants's `default`. Otherwise, using `[]` will override any lower-precedence sources.
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_LISTOPT="['foo','bar']"
@@ -200,7 +200,7 @@ Like with command-line flags, you can leave off the `[]` to _append_ elements:
 PANTS_SCOPE_LISTOPT=foo
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -210,7 +210,7 @@ listopt = [
 ]
 ```
 
-### Add/remove semantics
+#### Add/remove semantics
 
 List values have some extra semantics:
 
@@ -260,23 +260,23 @@ listopt.remove = [3, 4]
 But note that this only works in Pants's `.toml` config files, not in environment variables or command-line flags.
 :::
 
-## Dict values
+### Dict values
 
 Dict values are parsed as Python dict literals on the command-line and environment variables, so you must quote string keys and values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-dictopt="{'foo':1,'bar':2}"
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_DICTOPT="{'foo':1,'bar':2}"
 ```
 
-### Config file entries:
+#### Config file entries:
 
 You can use TOML's [nested table features](https://toml.io/en/v1.0.0#inline-table). These are equivalent:
 
@@ -301,7 +301,7 @@ dictopt = """{
 }"""
 ```
 
-### Add/replace semantics
+#### Add/replace semantics
 
 - A value can be preceded by `+`, which will _update_ the value obtained from lower-precedence sources with the entries.
 - Otherwise, the value _replaces_ the one obtained from lower-precendence sources.
@@ -320,7 +320,7 @@ pants --scope-dictopt="{'foo':42,'baz':3}"
 
 will set the value to `{'foo': 42, 'baz': 3}`.
 
-# Reading individual option values from files
+## Reading individual option values from files
 
 If an option value is too large or elaborate to use directly, or if you don't want to hard-code
 values directly in `pants.toml`, you can set the value of any option to the string
@@ -355,7 +355,7 @@ do so by `kill`ing it (after using `ps -ef | grep pantsd` to find its pid), or b
 Pants once with `--no-pantsd`.
 :::
 
-# `.pants.rc` file
+## `.pants.rc` file
 
 You can set up personal Pants config files, using the same TOML syntax as `pants.toml`. By default, Pants looks for the paths `/etc/pantsrc`, `~/.pants.rc`, and `.pants.rc` in the repository root.
 

--- a/docs/docs/using-pants/key-concepts/source-roots.mdx
+++ b/docs/docs/using-pants/key-concepts/source-roots.mdx
@@ -13,7 +13,7 @@ Go does have a notion of source roots: where your `go.mod` is located. However, 
 Shell does not have any notion of source roots.
 :::
 
-# What are source roots?
+## What are source roots?
 
 Some project layouts use top-level folders for namespace purposes, but have the code live underneath. However, the code's imports will ignore these top-level folders, thanks to mechanisms like the `$PYTHONPATH` and the JVM classpath. _Source roots_ are a generic equivalent of these concepts.
 
@@ -44,7 +44,7 @@ pkgutil.get_data("project.config", "prod.json")
 
 In the example above, `src/python` is a source root. So, when some code says `from project.app import App`, Pants can know that this corresponds to the code in `src/python/project/app.py`.
 
-# Configuring source roots
+## Configuring source roots
 
 There are two ways to configure source roots:
 
@@ -60,7 +60,7 @@ src/python
 src/rust
 ```
 
-## Configuring source roots using patterns
+### Configuring source roots using patterns
 
 You can provide a set of patterns that match your source roots:
 
@@ -85,7 +85,7 @@ You can use `*` as a glob. For example, `root_patterns = ["/src/*"]` would consi
 - `src/java`
 - `src/assets`
 
-### Configuring no source roots
+#### Configuring no source roots
 
 Many projects do not have any top-level folders used for namespacing.
 
@@ -125,7 +125,7 @@ The default value of the `root_patterns` config key is `["/", "src", "src/python
 These capture a range of common cases, including a source root at the root of the repository. If your source roots match these patterns, you don't need to explicitly configure them.
 :::
 
-## Configuring source roots using marker files
+### Configuring source roots using marker files
 
 You can also denote your source roots using specially-named marker files. To do so, first pick a name (or multiple names) to use:
 
@@ -182,15 +182,15 @@ import server.server.app
 from utils.utils.strutil import capitalize
 ```
 
-# Examples
+## Examples
 
 These project structures are all valid; Pants does not expect you to reorganize your codebase to use the tool.
 
-## `src/<lang>` setup
+### `src/<lang>` setup
 
 This setup is common in "polyglot" repositories: i.e. repos with multiple languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -228,7 +228,7 @@ This setup is common in "polyglot" repositories: i.e. repos with multiple langua
 
 While we have tests in a separate source root here, it's also valid to have tests colocated with their src files.
 
-### Example imports:
+#### Example imports:
 
 ```python
 # Python
@@ -242,7 +242,7 @@ import org.pantsbuild.project.App
 import org.pantsbuild.project.util.Math
 ```
 
-### Config:
+#### Config:
 
 ```toml title="pants.toml"
 [source]
@@ -255,9 +255,9 @@ root_patterns = [
 
 Note that we organized our 3rdparty requirements in the top-level folders `3rdparty/python` and `3rdparty/java`, but we do not need to include them as source roots because we do not have any first-party code there.
 
-## Multiple top-level projects
+### Multiple top-level projects
 
-### Project:
+#### Project:
 
 This layout has lots of nesting; this is only one possible way to organize the repository.
 
@@ -289,7 +289,7 @@ This layout has lots of nesting; this is only one possible way to organize the r
         └── spa.js
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 import ads.billing.calculate_bill
@@ -299,7 +299,7 @@ from base.util.math import add_two
 
 Note that even though the projects live in different top-level folders, you are still able to import from other projects. If you would like to limit this, you can use `pants dependents` or `pants dependencies` in CI to track where imports are being used. See [Project introspection](../project-introspection.mdx).
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 
@@ -320,11 +320,11 @@ root_patterns = [
 ]
 ```
 
-## No source root
+### No source root
 
 Warning: while this project structure is valid, it often does not scale as well as your codebase grows, such as adding new languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -340,7 +340,7 @@ Warning: while this project structure is valid, it often does not scale as well 
 └── pyproject.toml
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 from project.app import App
@@ -349,7 +349,7 @@ from project.util.math import add_two
 pkgutil.get_data("project.config", "prod.json")
 ```
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 

--- a/docs/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/docs/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -23,7 +23,7 @@ To reduce boilerplate, some targets also generate other targets:
 - `shell_sources` -> `shell_source`
 - `go_mod` -> `go_third_party_package`
 
-# BUILD files
+## BUILD files
 
 Targets are defined in files with the name `BUILD`. For example:
 
@@ -45,7 +45,7 @@ All target types have a `name` field, which is used to identify the target. Targ
 
 You can autoformat `BUILD` files by enabling a `BUILD` file formatter by adding it to `[GLOBAL].backend_packages` in `pants.toml` (such as `pants.backend.build_files.fmt.black` [or others](./backends.mdx)). Then to format, run `pants fmt '**/BUILD'` or `pants fmt ::` (formats everything).
 
-## Environment variables
+### Environment variables
 
 BUILD files are very hermetic in nature with no support for using `import` or other I/O operations. In order to have dynamic data in BUILD files, you may inject values from the local environment using the `env()` function. It takes the variable name and optional default value as arguments.
 
@@ -60,7 +60,7 @@ python_distribution(
 )
 ```
 
-# Target addresses
+## Target addresses
 
 A target is identified by its unique address, in the form `path/to/dir:name`. The above example has the addresses `helloworld/greet:tests` and `helloworld/greet:bin`.
 
@@ -83,7 +83,7 @@ You can refer to this target with either `helloworld/greet:greet` or the abbrevi
 Addresses defined in the `BUILD` file at the root of your repository are prefixed with `//`, e.g. `//:my_tgt`.
 :::
 
-# `source` and `sources` field
+## `source` and `sources` field
 
 Targets like `python_test` and `resource` have a `source: str` field, while target generators like `python_tests` and `resources` have a `sources: list[str]` field. This determines which source files belong to the target.
 
@@ -123,7 +123,7 @@ Including the same file in the `source` / `sources` field for multiple targets c
 You can run `pants list path/to/file.ext` to see all "owning" targets to check if >1 target has the file in its `source` field.
 :::
 
-# `dependencies` field
+## `dependencies` field
 
 A target's dependencies determines which other first-party code and third-party requirements to include when building the target.
 
@@ -166,7 +166,7 @@ You can use the prefix `!!` to transitively exclude a dependency, meaning that e
 Transitive excludes can only be used in target types that conventionally are not depended upon by other targets, such as `pex_binary`, `python_distribution`, and `python_test` / `python_tests`. This is meant to limit confusion, as using `!!` in something like a `python_source` / `python_sources` target could result in surprising behavior for everything that depends on it. (Pants will print a helpful error when using `!!` when it's not legal.)
 :::
 
-# Field default values
+## Field default values
 
 As mentioned above in [BUILD files](./targets-and-build-files.mdx#build-files), most target fields have sensible defaults. And it's easy to override those values on a specific target. But applying the same non-default value on many targets can get unwieldy, error-prone and hard to maintain. Enter `__defaults__`.
 
@@ -215,7 +215,7 @@ To reset any modified defaults, simply override with the empty dict:
     __defaults__(all={})
 ```
 
-## Supporting optional plugin fields
+### Supporting optional plugin fields
 
 Normally Pants presents an error message when attempting to provide a default value for a field that doesn't exist for the target. However, some fields comes from plugins, and to support disabling a plugin without having to remove any default values referencing any plugin fields it was providing, there is a `ignore_unknown_fields` option to use:
 
@@ -228,7 +228,7 @@ Normally Pants presents an error message when attempting to provide a default va
     )
 ```
 
-## Extending field defaults
+### Extending field defaults
 
 To add to a default value rather than replacing it, the current default value for a target field is available in the BUILD file using `<target>.<field>.default`. This allows you to augment a field's default value with much more precision. As an example, if you want to make the default sources for a `python_sources` target to work recursively you may specify a target augmenting the default sources field:
 
@@ -242,7 +242,7 @@ python_sources(
 )
 ```
 
-# Target generation
+## Target generation
 
 To reduce boilerplate, Pants provides target types that generate other targets. For example:
 
@@ -320,7 +320,7 @@ It's useful for metadata to be as fine-grained as feasible, such as by using the
 [`pants tailor ::`](../../getting-started/initial-configuration.mdx#5-generate-build-files) will automatically create targets that only apply metadata for the directory.
 :::
 
-# Parametrizing targets
+## Parametrizing targets
 
 It can be useful to create multiple targets describing the same entity, each with different metadata. For example:
 

--- a/docs/docs/using-pants/remote-caching-&-execution/index.mdx
+++ b/docs/docs/using-pants/remote-caching-&-execution/index.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Overview
+## Overview
 
 By default, Pants executes processes in a local [environment](../environments.mdx) on the system on which it is run, and caches the results of those processes locally as well. Besides this "local execution" mode of operation, Pants also supports two distributed modes of operation:
 
@@ -15,7 +15,7 @@ By default, Pants executes processes in a local [environment](../environments.md
 
 Pants does this by using the "Remote Execution API" to converse with the remote cache or remote execution server. Pants also [supports some additional providers](./remote-caching.mdx) other than Remote Execution API that provide only remote caching, without execution.
 
-## What is Remote Execution API?
+### What is Remote Execution API?
 
 Pants is compatible with remote caching and remote execution servers that comply with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI protocol is supported by several different server and client projects including Bazel and of course Pants.
 
@@ -31,7 +31,7 @@ Pants calls the CAS a "store server" and the execution service an "execution ser
 
 The REAPI model contains the notion of an "instance." An "instance" is a distinct deployment of a CAS and/or execution service that is given a specific name. All REAPI operations send an instance name to the server, thus a single network endpoint can conceivably support multiple REAPI deployments.
 
-# Server compatibility
+## Server compatibility
 
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
@@ -53,6 +53,6 @@ Bazel Remote Cache supports local disk, S3, GCS, and Azure Blob storage options 
 
 There are a few [other](https://github.com/bazelbuild/remote-apis) systems and services in this space, but they have not, to our knowledge, been tested with Pants. Let us know if you have any experience with them!
 
-# Resources
+## Resources
 
 - The [remote-apis-testing project](https://gitlab.com/remote-apis-testing/remote-apis-testing) maintains a compatibility test suite of the various server and client implementations of REAPI.

--- a/docs/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
+++ b/docs/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# What is remote caching?
+## What is remote caching?
 
 Remote caching allows Pants to store and retrieve the results of process execution to and from a remote server, rather than only using your machine's local Pants cache. This allows Pants to efficiently share a cache across different runs and different machines, for example, all of your CI workers sharing the same fine-grained cache.
 
@@ -15,13 +15,13 @@ Pants supports several remote caching providers:
 - GitHub Actions Cache
 - Local file system
 
-# Remote Execution API
+## Remote Execution API
 
-## Server
+### Server
 
 See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information about REAPI-compatible caches.
 
-## Pants Configuration
+### Pants Configuration
 
 After you have either set up a REAPI cache server or obtained access to one, the next step is to point Pants to it so that Pants will use it to read and write process results.
 
@@ -37,7 +37,7 @@ remote_instance_name = "main"
 
 If the endpoint is using TLS, then the `remote_store_address` option would be specified with the `grpcs://` scheme, i.e. `"grpcs://cache.corp.example.com:8980"`.
 
-# GitHub Actions Cache
+## GitHub Actions Cache
 
 GitHub Actions provides a built-in caching service which Pants supports using for sharing caches across GitHub Actions runs (not with machines outside of GitHub Actions). It is typically used via the `actions/cache` action to cache whole directories and files, but Pants can use the same functionality for fine-grained caching.
 
@@ -45,7 +45,7 @@ GitHub Actions provides a built-in caching service which Pants supports using fo
 Support for this cache provider is still under development, with more refinement required. Please [let us know](/community/getting-help) if you use it and encounter errors or warnings.
 :::
 
-## Workflow
+### Workflow
 
 The values of the `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` environment variables need to be provided to Pants via the `[GLOBAL].remote_store_address` and `[GLOBAL].remote_oauth_bearer_token` options respectively. They are only provided to action calls (not shell steps that use `run: ...`). Include a step like the following in your jobs, which sets those options via environment variables, before executing any Pants commands:
 
@@ -58,7 +58,7 @@ The values of the `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` environment va
       core.exportVariable('PANTS_REMOTE_OAUTH_BEARER_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN);
 ```
 
-## Pants Configuration
+### Pants Configuration
 
 Once the GitHub values are configured, Pants will read the environment variables. You will also need to configure pants to read and write to the cache only while in CI, such as [via a `pants.ci.toml` configuration file](../using-pants-in-ci.mdx#configuring-pants-for-ci-pantscitoml-optional):
 
@@ -71,7 +71,7 @@ remote_cache_write = true
 
 If desired, you can also set `remote_instance_name` to a string that's included as a prefix on each cache key, which will be then be displayed in the 'Actions' > 'Caches' UI.
 
-# Local file system
+## Local file system
 
 Pants can cache "remotely" to a local file system path, which can be used for a networked mount cache, without having to pay the cost of storing Pants' local cache on the network mount too. This can also be used for testing/validation.
 
@@ -79,7 +79,7 @@ Pants can cache "remotely" to a local file system path, which can be used for a 
 Support for this cache provider is still under development, with more refinement required. Please [let us know](/community/getting-help) if you use it and encounter errors or warnings.
 :::
 
-## Pants Configuration
+### Pants Configuration
 
 To read and write the cache to `/path/to/cache`, you will need to configure `pants.toml` as follows:
 
@@ -90,6 +90,6 @@ remote_cache_read = true
 remote_cache_write = true
 ```
 
-# Reference
+## Reference
 
 Run `pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.

--- a/docs/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
+++ b/docs/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
@@ -9,17 +9,17 @@
 Remote execution support in Pants comes with several limitations. For example, Pants requires that the server's operating system match the client's operating system. In practice, this means that Pants must be running on Linux because all three major server projects generally only operate on Linux.
 :::
 
-# What is remote execution?
+## What is remote execution?
 
 "Remote execution" allows Pants to offload execution of processes to a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI standard is supported by several different server and client projects including Bazel and of course Pants.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote execution requires the availability of a REAPI-compatible execution server. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants
+### Pants
 
 After you have either set up a REAPI server or obtained access to one, the next step is to point Pants to it so that Pants may submit REAPI execution requests. The server should be running a CAS and execution service. These may be the same network endpoint, but for Pants' purposes, they are configured by different configuration options.
 
@@ -33,7 +33,7 @@ remote_execution_address = "grpc://build.corp.example.com:8980"
 remote_instance_name = "main"
 ```
 
-### Environment-specific settings
+#### Environment-specific settings
 
 The REAPI execution service selects a worker for a process by consulting the "platform properties" that are passed in a remote execution request. These platform properties are key/value pairs that are configured for particular workers in the server. Generally, you will configure these in the server (or be provided them by your server's administrator), and then configure Pants to match particular workers using their relevant platform properties.
 
@@ -52,7 +52,7 @@ remote_environment(
 
 Your `remote_environment` will also need to override any [environment-aware options](../environments.mdx) which configure the relevant tools used in your repository. For example: if building Python code, a Python interpreter must be available and matched via the environment-aware options of `[python-bootstrap]`. If using protobuf support, then you may also need `unzip` available in the remote execution environment in order to unpack the protoc archive. Etc.
 
-### Concurrency
+#### Concurrency
 
 Finally, you should configure Pants to limit the number of concurrent execution requests that are sent to the REAPI server. The `process_execution_remote_parallelism` option controls this concurrency. For example, if `process_execution_remote_parallelism` is set to `20`, then Pants will only send a maximum of 20 execution requests at a single moment of time.
 
@@ -72,7 +72,7 @@ remote_execution_extra_platform_properties = [
 process_execution_remote_parallelism = 20
 ```
 
-### TLS
+#### TLS
 
 You can enable TLS by prefixing the `remote_store_address` and `remote_execution_address` with `grpcs://` instead of `grpc://`.
 
@@ -93,7 +93,7 @@ remote_client_certs_path = "/etc/ssl/certs/client-cert.pem"
 remote_client_key_path = "/etc/ssl/certs/client-key.pem"
 ```
 
-# Reference
+## Reference
 
 For global options, run `pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.
 

--- a/docs/docs/using-pants/validating-dependencies.mdx
+++ b/docs/docs/using-pants/validating-dependencies.mdx
@@ -76,7 +76,7 @@ backend_packages.add = [
 This does not mean you should not use it, only that it is in "preview" mode meaning that things may change between releases without following our deprecation policy as we work on stabilizing this feature. See [the stabilization ticket](https://github.com/pantsbuild/pants/issues/17634) for what remains to be done for the visibility backend to graduate out of preview.
 :::
 
-# Dependencies and dependents
+## Dependencies and dependents
 
 The visibility rules operates on the dependency link between two targets. Dependencies are directional, so if target `A` depends on another target `B` the dependency goes from the "origin" target `A` -> `B`, we say that `B` is the **dependency** of `A`, while `A` is the **dependent** of `B`.
 
@@ -180,7 +180,7 @@ If your codebase has a very complex dependency graph, you may need to make sure 
 
 In this scenario, you may need to look into alternative solutions to codify these constraints. For example, to check for violations, you could query the dependencies of component `C1` (transitively) using the `dependencies` goal with the `--transitive` option to confirm none of the modules from component `C3` are listed. If there are some, you may find the `paths` goal helpful as it would show you exactly why a certain module from component `C1` depends on a given module in component `C3` if it is unclear.
 
-## Rule sets
+### Rule sets
 
 As there may be many targets and files with dependencies, odds are that they won't all share the same set of rules. The rules keywords accepts multiple sets of rules, or "rule sets", along with "selector rules" that is used to select which set to use for each target.
 
@@ -289,7 +289,7 @@ The previous example, using this alternative syntax for the selectors, would loo
   )
 ```
 
-## Glob syntax
+### Glob syntax
 
 The visibility rules are all about matching globs. There are two wildcards: the `*` matches anything except `/`, and the `**` matches anything including `/`. (For paths that is non-recursive and recursive globbing respectively.)
 
@@ -319,7 +319,7 @@ some/directory/*
 
 So far the rule globs have been matched from anywhere in the matched to path up to the end. To ensure the path begins with a certain pattern we'd have to provide full paths in our rules, like `src/python/proj/lib/file.py` if we want to make sure that our `file.py` is from the `src/` tree. To avoid lengthy and rigid rule globs hurting refactorings etc, there's a concept of "anchoring" the rule. That will apply the rule glob from a fixed point in the matched to path, and there are three such points: project root, rule declaration path and rule invocation path. The difference between declaration and invocation is explained below.
 
-#### Anchoring mode for path globs
+##### Anchoring mode for path globs
 
 The glob prefix specifies which "anchoring mode" to use, and are:
 
@@ -340,7 +340,7 @@ The glob prefix specifies which "anchoring mode" to use, and are:
 
 > 🚧 Regardless of anchoring mode, all rules are always anchored to the end of the matched path.
 
-#### Targeting non-source files
+##### Targeting non-source files
 
 So far most examples have been about providing rules that match source files. This will likely be the most common scenario, but other targets may just as well need to be considered. For the general case, non-source file targets will be matched using the directory where it has been declared (the path containing the BUILD file in most cases).
 
@@ -391,7 +391,7 @@ __dependencies_rules__(
 )
 ```
 
-## Rule actions
+### Rule actions
 
 When a matching rule is found for a path, the path is either allowed or denied based on the rule's action. The dependency link as a whole is only allowed if both ends of the dependency allow it. By default a rule's action is `ALLOW`, but may be changed to `DENY` or `WARN`. The `WARN` action logs a warning message rather than raising an error, but will otherwise allow the dependency.
 

--- a/versioned_docs/version-2.11/docs/contributions/development/internal-architecture.mdx
+++ b/versioned_docs/version-2.11/docs/contributions/development/internal-architecture.mdx
@@ -5,9 +5,9 @@
 
 ---
 
-# Rule Graph Construction
+## Rule Graph Construction
 
-## Overview
+### Overview
 
 Build logic in [Pants](https://www.pantsbuild.org/) is declared using collections of `@rules` with recursively memoized and invalidated results. This framework (known as Pants' "Engine") has similar goals to Bazel's [Skyframe](https://bazel.build/designs/skyframe.html) and the [Salsa](https://github.com/salsa-rs/salsa) framework: users define logic using a particular API, and the framework manages tracking the dependencies between nodes in a runtime graph.
 
@@ -15,11 +15,11 @@ In order to maximize the amount of work that can be reused at runtime, Pants sta
 
 Concepts used in compilers, including live variable analysis and monomorphization, can also be useful in rule graph construction to minimize rule identities and pre-decide which versions of their dependencies they will use.
 
-## Concepts
+### Concepts
 
 A successfully constructed `RuleGraph` contains a graph where nodes have one of three types, `Rule`s, `Query`s, and `Param`s, which map fairly closely to what a Pants `@rule` author consumes. The edges between nodes represent dependencies: `Query`s are always roots of the graph, `Param`s are always leaves, and `Rule`s represent the end user logic making up all of the internal nodes of the graph.
 
-### Rules
+#### Rules
 
 A `Rule` is a function or coroutine with all of its inputs declared as part of its type signature. The end user type signature is made up of:
 
@@ -31,13 +31,13 @@ In the `RuleGraph`, these are encoded in a [Rule](https://github.com/pantsbuild/
 
 `Rule`s never refer to one another by name (i.e., they do not call one another by name): instead, their signature declares their requirements in terms of input/output types, and rule graph construction decides which potential dependencies will provide those requirements.
 
-### Queries
+#### Queries
 
 The roots/entrypoints of a `RuleGraph` are `Query`s, which should correspond one-to-one to external callsites that use the engine to request that values are computed. A `Query` has an output type, and a series of input types: `Query(output_type, (*input_types))`.
 
 If a user makes a request to the engine that does not have a corresponding `Query` declared, the engine fails rather than attempting to dynamically determine which `Rules` to use to answer the `Query`: how a `RuleGraph` is constructed should show why that is the case.
 
-### Params
+#### Params
 
 `Params` are typed, comparable (`eq`/`hash`) values that represent both the inputs to `Rules`, and the building block of the runtime memoization key for a `Rule`. The set of `Params` (unique by type) that are consumed to create a `Rule`'s inputs (plus the `Rule`'s own identity) make up the memoization key for a runtime instance of the `Rule`.
 
@@ -47,7 +47,7 @@ The `Param`s that are available to a `Rule` are made available by the `Rule`'s d
 
 `Params` flow down the graph from `Query`s and the provided `Param`s of `Get`s: their presence does not need to be re-declared at each intermediate callsite. When a `Rule` consumes a `Param` as a positional argument, that `Param` will no longer be available to that `Rule`'s dependencies (but it might still be present in other subgraphs adjacent to that `Rule`).
 
-## Goals
+### Goals
 
 The goals of `RuleGraph` construction are:
 
@@ -61,7 +61,7 @@ If either of the goals were removed, `RuleGraph` construction might be more stra
 
 But both of the goals are important because together they allow for an API that is easy to write `Rule`s for, with minimal boilerplate required to get the inputs needed for a `Rule` to compute a value, and minimal invalidation. Because the identity of a `Rule` is computed from its transitive input `Param`s rather than from its positional arguments, `Rule`s can accept arbitrarily-many large input values (which don't need to implement hash) with no impact on its memoization hit rate.
 
-## Constraints
+### Constraints
 
 There are a few constraints that decide which `Rule`s are able to provide dependencies for one another:
 
@@ -71,7 +71,7 @@ There are a few constraints that decide which `Rule`s are able to provide depend
 - `provided_params` - When deciding whether one `Rule` can use another `Rule` to provide the output type of a `Get`, a constraint is applied that the candidate depedency must (transitively) consume the `Param` that is provided by the `Get`.
   - For example: if a `Rule` `z` has a `Get(A, B)`, only `Rule`s that compute an `A` and (transitively) consume a `B` are eligible to be used. This also means that a `Param` `A` which is already in scope for `Rule` `z` is not eligible to be used, because it would trivially not consume `B`.
 
-## Implementation
+### Implementation
 
 As of [3a188a1e06](https://github.com/pantsbuild/pants/blob/3a188a1e06d8c27ff86d8c311ff1b2bdea0d39ff/src/rust/engine/rule_graph/src/builder.rs#L202-L219), we construct a `RuleGraph` using a combination of data flow analysis and some homegrown (and likely problematic: see the "Issue Overview") node splitting on the call graph of `Rule`s.
 

--- a/versioned_docs/version-2.11/docs/introduction/welcome-to-pants.mdx
+++ b/versioned_docs/version-2.11/docs/introduction/welcome-to-pants.mdx
@@ -5,11 +5,11 @@
 
 ---
 
-# What is Pants?
+## What is Pants?
 
 Pants is a fast, scalable, user-friendly build and developer workflow system for codebases of all sizes, including yours!
 
-# What does Pants do?
+## What does Pants do?
 
 Pants installs, orchestrates and runs dozens of standard underlying tools - compilers, code generators, dependency resolvers, test runners, linters, formatters, packagers, REPLs and more - composing them into a single stable, hermetic toolchain, and speeding up your workflows via caching and concurrency.
 
@@ -17,13 +17,13 @@ Pants is designed to be easy to adopt, use, and extend. It doesn't require you t
 
 Pants is currently focused on Python, Go, Java, Scala, Shell, and Docker, with more languages and frameworks coming soon. [The Pants community](/community/members) is friendly and helpful, and supported by [Toolchain](https://toolchain.com/), a venture-backed company whose mission is to enable fast, stable, ergonomic developer workflows for everyone.
 
-# Who is Pants for?
+## Who is Pants for?
 
 Pants is useful for repos of all sizes, but is particularly valuable for those containing multiple distinct but interdependent pieces.
 
 Pants works well with (but does not require) a [_monorepo_ architecture](https://blog.pantsbuild.org/the-monorepo-approach-to-code-management/): a codebase containing multiple projects—often using multiple programming languages and frameworks—in a single unified repository. If you want to scale your codebase without breaking it up into multiple disconnected repos, with all the versioning and maintenance headaches that causes, Pants provides the tooling for you to do so effectively.
 
-# What are the main features of Pants?
+## What are the main features of Pants?
 
 Pants is designed for fast, consistent, ergonomic builds. Some noteworthy features include:
 
@@ -36,7 +36,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 - Extensibility and customizability via a plugin API
 - Code introspection features
 
-# Which languages and frameworks does Pants support?
+## Which languages and frameworks does Pants support?
 
 - Pants [ships](page:language-support) with support for [Python](../python/overview/index.mdx), [Go](../go/index.mdx), [Java](../java-and-scala/index.mdx), [Scala](../java-and-scala/index.mdx) and [Shell](../shell/index.mdx).
 - Pants supports a wide range of code generators (such as Thrift, Protobuf, Scrooge and Avro), linters and formatters, and it is easy to add support for new or custom ones
@@ -45,7 +45,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 We're listening to the community for which languages, frameworks and tools we should support next, so let us know about your needs by [opening an issue](https://github.com/pantsbuild/pants/issues/new/choose) on GitHub or [chatting with us](/community/members) about it on the community Slack!
 Pants was designed for extensibility, and we welcome [contributions](../contributions/index.mdx)!
 
-# How does Pants work?
+## How does Pants work?
 
 The core of Pants is its execution engine, which sequences and coordinates all the underlying work. The engine is written in Rust, for performance. The underlying work is performed by executing _rules_, which are typed Python 3 async coroutines for familiarity and simplicity.
 
@@ -53,17 +53,17 @@ The engine is designed so that fine-grained invalidation, concurrency, hermetici
 
 See [here](./how-does-pants-work.mdx) for more details about the Pants engine.
 
-# Is Pants similar to X?
+## Is Pants similar to X?
 
 Pants (v2) is a leap forward in the evolution of build systems, a category that runs from the venerable Make through Ant, Maven, Gradle and SBT, to Bazel, Please, Buck, Pants v1 and others.
 
 Its design leans on ideas and inspiration from these earlier tools, while optimizing not just for speed and correctness, but also for ease of adoption, ease of use and ease of extension, all for real-world use cases at a variety of teams.
 
-# Who uses Pants?
+## Who uses Pants?
 
 Pants is making engineering teams productive and happy at a range of companies and organizations. See a sample of them [here](page:who-uses-pants)!
 
-# Who develops Pants?
+## Who develops Pants?
 
 Pants is an open-source software project, developed at [github.com/pantsbuild/pants](https://github.com/pantsbuild/pants). Pants is released under the [Apache License 2.0](https://github.com/pantsbuild/pants/blob/master/LICENSE).
 

--- a/versioned_docs/version-2.11/docs/using-pants/key-concepts/goals.mdx
+++ b/versioned_docs/version-2.11/docs/using-pants/key-concepts/goals.mdx
@@ -17,7 +17,7 @@ To see the current list of goals, run:
 
 You'll see more goals activated as you activate more [backends](./backends.mdx).
 
-# Running goals
+## Running goals
 
 For example:
 
@@ -44,7 +44,7 @@ Finally, Pants supports running goals in a `--loop`: in this mode, all goals spe
 
 Use `Ctrl+C` to exit the `--loop`.
 
-# Goal arguments
+## Goal arguments
 
 Some simple goals—such as the `roots` goal—do not require arguments. But most goals require some arguments to work on.
 
@@ -67,7 +67,7 @@ TOML                         2        65       14        18       33          0
 Note the single-quotes around the file pattern `'**'`. This is so that your shell doesn't attempt to expand the pattern, but instead passes it unaltered to Pants.
 :::
 
-## File arguments vs. target arguments
+### File arguments vs. target arguments
 
 Goal arguments can be of one of two types:
 
@@ -96,7 +96,7 @@ For example, `./pants list ::` will find every target in your project.
 See [Advanced target selection](../advanced-target-selection.mdx) for alternative techniques to specify which files/targets to run on.
 :::
 
-## Goal options
+### Goal options
 
 Many goals also have [options](./options.mdx) to change how they behave. Every option in Pants can be set via an environment variable, config file, and the command line.
 

--- a/versioned_docs/version-2.11/docs/using-pants/key-concepts/options.mdx
+++ b/versioned_docs/version-2.11/docs/using-pants/key-concepts/options.mdx
@@ -7,7 +7,7 @@ A deep dive into how options may be configured.
 
 ---
 
-# Option scopes
+## Option scopes
 
 Options are partitioned into named _scopes_.
 
@@ -15,7 +15,7 @@ Some systemwide options belong in the _global scope_. For example, the `--level`
 
 Other options belong to a _subsystem scope_. A _subsystem_ is simply a collection of related options, in a scope. For example, the `pytest` subsystem contains options related to [Python's test framework pytest](../../../reference/subsystems/pytest.mdx).
 
-# Setting options
+## Setting options
 
 Every option can be set in the following ways, in order of precedence:
 
@@ -27,7 +27,7 @@ If an option isn't set in one of these ways, it will take on a default value.
 
 You can inspect both the current value and the default value by using `./pants help $scope` or `./pants help-advanced $scope`, e.g. `./pants help global`.
 
-## Command-line flags
+### Command-line flags
 
 Global options are set using an unqualified flag:
 
@@ -41,7 +41,7 @@ Subsystem options are set by providing the flag, with the name prefixed with the
 ./pants --source-root-patterns="['^ext']"
 ```
 
-## Environment variables
+### Environment variables
 
 Global options are set using the environment variable `PANTS_{OPTION_NAME}`:
 
@@ -58,7 +58,7 @@ PANTS_SOURCE_ROOT_PATTERNS="['^ext']" ./pants ...
 
 Note that the scope and option name are upper-cased, and any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `MULTIWORD_NAME`.
 
-## Config file entries
+### Config file entries
 
 Global options are set in the `GLOBAL` section of the config file:
 
@@ -83,7 +83,7 @@ Additionally, a few different variables may be interpolated into strings in conf
 pythonpath = ["%(buildroot)s/examples"]
 ```
 
-# Option types
+## Option types
 
 Every option has a type, and any values you set must be of that type.
 
@@ -97,25 +97,25 @@ The option types are:
 
 A list-valued option may also declare a specific type for its members (e.g., a list of strings, or a list of integers).
 
-## String and integer values
+### String and integer values
 
 Standalone string and integer values are written without quotes. Any quotes will be considered part of the value, after shell escaping.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-intopt=42
 ./pants --scope-stropt=qux
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_INTOPT=42
 PANTS_SCOPE_STROPT=qux
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml
 [scope]
@@ -123,11 +123,11 @@ intopt = 42
 stropt = "qux"
 ```
 
-## Boolean values
+### Boolean values
 
 Boolean values can be specified using the special strings `true` and `false`. When specifying them via command-line flags you can also use the `--boolopt/--no-boolopt` syntax.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-boolopt=true
@@ -135,24 +135,24 @@ Boolean values can be specified using the special strings `true` and `false`. Wh
 ./pants --no-scope-boolopt
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_BOOLOPT=true
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml
 [scope]
 boolopt = true
 ```
 
-## List values
+### List values
 
 List values are parsed as Python list literals, so you must quote string values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-listopt="['foo','bar']"
@@ -164,7 +164,7 @@ You can also leave off the `[]` to _append_ elements. So we can rewrite the abov
 ./pants --scope-listopt=foo --scope-listopt=bar
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_LISTOPT="['foo','bar']"
@@ -176,7 +176,7 @@ Like with command-line flags, you can leave off the `[]` to _append_ elements:
 PANTS_SCOPE_LISTOPT=foo
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml
 [scope]
@@ -186,7 +186,7 @@ listopt = [
 ]
 ```
 
-### Add/remove semantics
+#### Add/remove semantics
 
 List values have some extra semantics:
 
@@ -236,23 +236,23 @@ listopt.remove = [3, 4]
 But note that this only works in Pants's `.toml` config files, not in environment variables or command-line flags.
 :::
 
-## Dict values
+### Dict values
 
 Dict values are parsed as Python dict literals on the command-line and environment variables, so you must quote string keys and values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-dictopt="{'foo':1,'bar':2}"
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_DICTOPT="{'foo':1,'bar':2}"
 ```
 
-### Config file entries:
+#### Config file entries:
 
 You can use TOML's [nested table features](https://toml.io/en/v1.0.0#inline-table). These are equivalent:
 
@@ -277,7 +277,7 @@ dictopt = """{
 }"""
 ```
 
-### Add/replace semantics
+#### Add/replace semantics
 
 - A value can be preceded by `+`, which will _update_ the value obtained from lower-precedence sources with the entries.
 - Otherwise, the value _replaces_ the one obtained from lower-precendence sources.
@@ -296,7 +296,7 @@ will set the value to `{'foo': 42, 'bar': 2, 'baz': 3}`, and
 
 will set the value to `{'foo': 42, 'baz': 3}`.
 
-# `.pants.rc` file
+## `.pants.rc` file
 
 You can set up personal Pants config files, using the same TOML syntax as `pants.toml`. By default, Pants looks for the paths `/etc/pantsrc`, `~/.pants.rc`, and `.pants.rc` in the repository root.
 

--- a/versioned_docs/version-2.11/docs/using-pants/key-concepts/source-roots.mdx
+++ b/versioned_docs/version-2.11/docs/using-pants/key-concepts/source-roots.mdx
@@ -13,7 +13,7 @@ Go does have a notion of source roots: where your `go.mod` is located. However, 
 Shell does not have any notion of source roots.
 :::
 
-# What are source roots?
+## What are source roots?
 
 Some project layouts use top-level folders for namespace purposes, but have the code live underneath. However, the code's imports will ignore these top-level folders, thanks to mechanisms like the `$PYTHONPATH` and the JVM classpath. _Source roots_ are a generic equivalent of these concepts.
 
@@ -44,7 +44,7 @@ pkgutil.get_data("project.config", "prod.json")
 
 In the example above, `src/python` is a source root. So, when some code says `from project.app import App`, Pants can know that this corresponds to the code in `src/python/project/app.py`.
 
-# Configuring source roots
+## Configuring source roots
 
 There are two ways to configure source roots:
 
@@ -60,7 +60,7 @@ src/python
 src/rust
 ```
 
-## Configuring source roots using patterns
+### Configuring source roots using patterns
 
 You can provide a set of patterns that match your source roots:
 
@@ -85,7 +85,7 @@ You can use `*` as a glob. For example, `root_patterns = ["/src/*"]` would consi
 - `src/java`
 - `src/assets`
 
-### Configuring no source roots
+#### Configuring no source roots
 
 Many projects do not have any top-level folders used for namespacing.
 
@@ -125,7 +125,7 @@ The default value of the `root_patterns` config key is `["/", "src", "src/python
 These capture a range of common cases, including a source root at the root of the repository. If your source roots match these patterns, you don't need to explicitly configure them.
 :::
 
-## Configuring source roots using marker files
+### Configuring source roots using marker files
 
 You can also denote your source roots using specially-named marker files. To do so, first pick a name (or multiple names) to use:
 
@@ -182,15 +182,15 @@ import server.server.app
 from utils.utils.strutil import capitalize
 ```
 
-# Examples
+## Examples
 
 These project structures are all valid; Pants does not expect you to reorganize your codebase to use the tool.
 
-## `src/<lang>` setup
+### `src/<lang>` setup
 
 This setup is common in "polyglot" repositories: i.e. repos with multiple languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -228,7 +228,7 @@ This setup is common in "polyglot" repositories: i.e. repos with multiple langua
 
 While we have tests in a separate source root here, it's also valid to have tests colocated with their src files.
 
-### Example imports:
+#### Example imports:
 
 ```python
 # Python
@@ -242,7 +242,7 @@ import org.pantsbuild.project.App
 import org.pantsbuild.project.util.Math
 ```
 
-### Config:
+#### Config:
 
 ```toml title="pants.toml"
 [source]
@@ -255,9 +255,9 @@ root_patterns = [
 
 Note that we organized our 3rdparty requirements in the top-level folders `3rdparty/python` and `3rdparty/java`, but we do not need to include them as source roots because we do not have any first-party code there.
 
-## Multiple top-level projects
+### Multiple top-level projects
 
-### Project:
+#### Project:
 
 This layout has lots of nesting; this is only one possible way to organize the repository.
 
@@ -289,7 +289,7 @@ This layout has lots of nesting; this is only one possible way to organize the r
         └── spa.js
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 import ads.billing.calculate_bill
@@ -299,7 +299,7 @@ from base.util.math import add_two
 
 Note that even though the projects live in different top-level folders, you are still able to import from other projects. If you would like to limit this, you can use `./pants dependees` or `./pants dependencies` in CI to track where imports are being used. See [Project introspection](../project-introspection.mdx).
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 
@@ -320,11 +320,11 @@ root_patterns = [
 ]
 ```
 
-## No source root
+### No source root
 
 Warning: while this project structure is valid, it often does not scale as well as your codebase grows, such as adding new languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -340,7 +340,7 @@ Warning: while this project structure is valid, it often does not scale as well 
 └── pyproject.toml
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 from project.app import App
@@ -349,7 +349,7 @@ from project.util.math import add_two
 pkgutil.get_data("project.config", "prod.json")
 ```
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 

--- a/versioned_docs/version-2.11/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/versioned_docs/version-2.11/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -23,7 +23,7 @@ To reduce boilerplate, some targets also generate other targets:
 - `shell_sources` -> `shell_source`
 - `go_mod` -> `go_third_party_package`
 
-# BUILD files
+## BUILD files
 
 Targets are defined in files with the name `BUILD`. For example:
 
@@ -45,7 +45,7 @@ All target types have a `name` field, which is used to identify the target. Targ
 
 Use [`./pants tailor`](../../getting-started/initial-configuration.mdx#5-generate-build-files) to automate generating BUILD files, and [`./pants update-build-files`](../../../reference/goals/update-build-files.mdx) to reformat them (using `black`, [by default](../../../reference/goals/update-build-files.mdx#section-formatter)).
 
-# Target addresses
+## Target addresses
 
 A target is identified by its unique address, in the form `path/to/dir:name`. The above example has the addresses `helloworld/greet:tests` and `helloworld/greet:bin`.
 
@@ -68,7 +68,7 @@ You can refer to this target with either `helloworld/greet:greet` or the abbrevi
 Addressed defined in the `BUILD` file at the root of your repository are prefixed with `//`, e.g. `//:my_tgt`.
 :::
 
-# `source` and `sources` field
+## `source` and `sources` field
 
 Targets like `python_test` and `resource` have a `source: str` field, while target generators like `python_tests` and `resources` have a `sources: list[str]` field. This determines which source files belong to the target.
 
@@ -108,7 +108,7 @@ Including the same file in the `source` / `sources` field for multiple targets c
 You can run `./pants list path/to/file.ext` to see all "owning" targets to check if >1 target has the file in its `source` field.
 :::
 
-# `dependencies` field
+## `dependencies` field
 
 A target's dependencies determines which other first-party code and third-party requirements to include when building the target.
 
@@ -151,7 +151,7 @@ You can use the prefix `!!` to transitively exclude a dependency, meaning that e
 Transitive excludes can only be used in target types that conventionally are not dependend upon by other targets, such as `pex_binary` and `python_test` / `python_tests`. This is meant to limit confusion, as using `!!` in something like a `python_source` / `python_sources` target could result in surprising behavior for everything that depends on it. (Pants will print a helpful error when using `!!` when it's not legal.)
 :::
 
-# Target generation
+## Target generation
 
 To reduce boilerplate, Pants provides target types that generate other targets. For example:
 
@@ -209,7 +209,7 @@ It's useful for metadata to be as fine-grained as feasible, such as by using the
 [`./pants tailor`](../../getting-started/initial-configuration.mdx#5-generate-build-files) will automatically create targets that only apply metadata for the directory.
 :::
 
-# Parametrizing targets
+## Parametrizing targets
 
 It can be useful to create multiple targets describing the same entity, each with different metadata. For example:
 

--- a/versioned_docs/version-2.11/docs/using-pants/remote-caching-&-execution/index.mdx
+++ b/versioned_docs/version-2.11/docs/using-pants/remote-caching-&-execution/index.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Overview
+## Overview
 
 Ordinarily, Pants executes processes locally on the system on which it is run and also caches the results of those processes locally as well. Besides this "local execution" mode of operation, Pants also supports two distributed modes of operation:
 
@@ -15,7 +15,7 @@ Ordinarily, Pants executes processes locally on the system on which it is run an
 
 Pants does this by using the "Remote Execution API" to converse with the remote cache or remote execution server.
 
-## What is Remote Execution API?
+### What is Remote Execution API?
 
 Pants is compatible with remote caching and remote execution servers that comply with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI protocol is supported by several different server and client projects including Bazel and of course Pants.
 
@@ -27,7 +27,7 @@ Pants calls the CAS a "store server" and the execution service an "execution ser
 
 The REAPI model contains the notion of an "instance." An "instance" is a distinct deployment of a CAS and/or execution service that is given a specific name. All REAPI operations send an instance name to the server, thus a single network endpoint can conceivably support multiple REAPI deployments.
 
-# Server compatibility
+## Server compatibility
 
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
@@ -37,6 +37,6 @@ In order to use remote caching or remote execution, Pants will need access to a 
 
 **Note**: Setup of a remote execution server is beyond the scope of this documentation. All three server projects have support channels on the BuildTeamWorld Slack. [Go here to obtain an invite to that Slack.](https://bit.ly/2SG1amT)
 
-# Resources
+## Resources
 
 - The [remote-apis-testing project](https://gitlab.com/remote-apis-testing/remote-apis-testing) maintains a compatibility test suite of the various server and client implementations of REAPI.

--- a/versioned_docs/version-2.11/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
+++ b/versioned_docs/version-2.11/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
@@ -5,17 +5,17 @@
 
 ---
 
-# What is remote caching?
+## What is remote caching?
 
 Remote caching allows Pants to store and retrieve the results of process execution to and from a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"), rather than only using your machine's local Pants cache. This allows Pants to share a cache across different runs and different machines, for example, all of your CI workers sharing the same fine-grained cache.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote caching requires the availability of a REAPI-compatible cache. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants Configuration
+### Pants Configuration
 
 After you have either set up a REAPI cache server or obtained access to one, the next step is to point Pants to it so that Pants will use it to read and write process results.
 
@@ -31,6 +31,6 @@ remote_instance_name = "main"
 
 If the endpoint is using TLS, then the `remote_store_address` option would be specified with the `grpcs://` scheme, i.e. `"grpcs://cache.corp.example.com:8980"`.
 
-# Reference
+## Reference
 
 Run `./pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.

--- a/versioned_docs/version-2.11/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
+++ b/versioned_docs/version-2.11/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
@@ -9,17 +9,17 @@
 Remote execution support in Pants comes with several limitations. For example, Pants requires that the server's operating system match the client's operating system. In practice, this means that Pants must be running on Linux because all three major server projects generally only operate on Linux.
 :::
 
-# What is remote execution?
+## What is remote execution?
 
 "Remote execution" allows Pants to offload execution of processes to a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI standard is supported by several different server and client projects including Bazel and of course Pants.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote execution requires the availability of a REAPI-compatible execution server. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants
+### Pants
 
 After you have either set up a REAPI server or obtained access to one, the next step is to point Pants to it so that Pants may submit REAPI execution requests. The server should be running a CAS and execution service. These may be the same network endpoint, but for Pants' purposes, they are configured by different configuration options.
 
@@ -33,7 +33,7 @@ remote_execution_address = "grpc://build.corp.example.com:8980"
 remote_instance_name = "main"
 ```
 
-### Platform Properties
+#### Platform Properties
 
 The REAPI execution service selects a worker for a process by consulting the "platform properties" that are passed in a remote execution request. These platform properties are key/value pairs that are configured in the server. Generally, you will configure these in the server (or be provided them by your server's administrator), and then configure Pants to use what was configured.
 
@@ -50,7 +50,7 @@ remote_execution_extra_platform_properties = [
 ]
 ```
 
-### Concurrency
+#### Concurrency
 
 Finally, you should configure Pants to limit the number of concurrent execution requests that are sent to the REAPI server. The `process_execution_remote_parallelism` option controls this concurrency. For example, if `process_execution_remote_parallelism` is set to `20`, then Pants will only send a maximum of 20 execution requests at a single moment of time.
 
@@ -70,7 +70,7 @@ remote_execution_extra_platform_properties = [
 process_execution_remote_parallelism = 20
 ```
 
-### TLS
+#### TLS
 
 You can enable TLS by prefixing the `remote_store_address` and `remote_execution_address` with `grpcs://` instead of `grpc://`.
 
@@ -88,11 +88,11 @@ remote_instance_name = "main"
 remote_ca_certs_path = "/etc/ssl/certs/ca-certificates.crt"
 ```
 
-# Reference
+## Reference
 
 Run `./pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.
 
-# Limitations
+## Limitations
 
 The remote execution support in Pants is still experimental and comes with several limitations:
 

--- a/versioned_docs/version-2.12/docs/contributions/development/internal-architecture.mdx
+++ b/versioned_docs/version-2.12/docs/contributions/development/internal-architecture.mdx
@@ -5,9 +5,9 @@
 
 ---
 
-# Rule Graph Construction
+## Rule Graph Construction
 
-## Overview
+### Overview
 
 Build logic in [Pants](https://www.pantsbuild.org/) is declared using collections of `@rules` with recursively memoized and invalidated results. This framework (known as Pants' "Engine") has similar goals to Bazel's [Skyframe](https://bazel.build/designs/skyframe.html) and the [Salsa](https://github.com/salsa-rs/salsa) framework: users define logic using a particular API, and the framework manages tracking the dependencies between nodes in a runtime graph.
 
@@ -15,11 +15,11 @@ In order to maximize the amount of work that can be reused at runtime, Pants sta
 
 Concepts used in compilers, including live variable analysis and monomorphization, can also be useful in rule graph construction to minimize rule identities and pre-decide which versions of their dependencies they will use.
 
-## Concepts
+### Concepts
 
 A successfully constructed `RuleGraph` contains a graph where nodes have one of three types, `Rule`s, `Query`s, and `Param`s, which map fairly closely to what a Pants `@rule` author consumes. The edges between nodes represent dependencies: `Query`s are always roots of the graph, `Param`s are always leaves, and `Rule`s represent the end user logic making up all of the internal nodes of the graph.
 
-### Rules
+#### Rules
 
 A `Rule` is a function or coroutine with all of its inputs declared as part of its type signature. The end user type signature is made up of:
 
@@ -31,13 +31,13 @@ In the `RuleGraph`, these are encoded in a [Rule](https://github.com/pantsbuild/
 
 `Rule`s never refer to one another by name (i.e., they do not call one another by name): instead, their signature declares their requirements in terms of input/output types, and rule graph construction decides which potential dependencies will provide those requirements.
 
-### Queries
+#### Queries
 
 The roots/entrypoints of a `RuleGraph` are `Query`s, which should correspond one-to-one to external callsites that use the engine to request that values are computed. A `Query` has an output type, and a series of input types: `Query(output_type, (*input_types))`.
 
 If a user makes a request to the engine that does not have a corresponding `Query` declared, the engine fails rather than attempting to dynamically determine which `Rules` to use to answer the `Query`: how a `RuleGraph` is constructed should show why that is the case.
 
-### Params
+#### Params
 
 `Params` are typed, comparable (`eq`/`hash`) values that represent both the inputs to `Rules`, and the building block of the runtime memoization key for a `Rule`. The set of `Params` (unique by type) that are consumed to create a `Rule`'s inputs (plus the `Rule`'s own identity) make up the memoization key for a runtime instance of the `Rule`.
 
@@ -47,7 +47,7 @@ The `Param`s that are available to a `Rule` are made available by the `Rule`'s d
 
 `Params` flow down the graph from `Query`s and the provided `Param`s of `Get`s: their presence does not need to be re-declared at each intermediate callsite. When a `Rule` consumes a `Param` as a positional argument, that `Param` will no longer be available to that `Rule`'s dependencies (but it might still be present in other subgraphs adjacent to that `Rule`).
 
-## Goals
+### Goals
 
 The goals of `RuleGraph` construction are:
 
@@ -61,7 +61,7 @@ If either of the goals were removed, `RuleGraph` construction might be more stra
 
 But both of the goals are important because together they allow for an API that is easy to write `Rule`s for, with minimal boilerplate required to get the inputs needed for a `Rule` to compute a value, and minimal invalidation. Because the identity of a `Rule` is computed from its transitive input `Param`s rather than from its positional arguments, `Rule`s can accept arbitrarily-many large input values (which don't need to implement hash) with no impact on its memoization hit rate.
 
-## Constraints
+### Constraints
 
 There are a few constraints that decide which `Rule`s are able to provide dependencies for one another:
 
@@ -71,7 +71,7 @@ There are a few constraints that decide which `Rule`s are able to provide depend
 - `provided_params` - When deciding whether one `Rule` can use another `Rule` to provide the output type of a `Get`, a constraint is applied that the candidate depedency must (transitively) consume the `Param` that is provided by the `Get`.
   - For example: if a `Rule` `z` has a `Get(A, B)`, only `Rule`s that compute an `A` and (transitively) consume a `B` are eligible to be used. This also means that a `Param` `A` which is already in scope for `Rule` `z` is not eligible to be used, because it would trivially not consume `B`.
 
-## Implementation
+### Implementation
 
 As of [3a188a1e06](https://github.com/pantsbuild/pants/blob/3a188a1e06d8c27ff86d8c311ff1b2bdea0d39ff/src/rust/engine/rule_graph/src/builder.rs#L202-L219), we construct a `RuleGraph` using a combination of data flow analysis and some homegrown (and likely problematic: see the "Issue Overview") node splitting on the call graph of `Rule`s.
 

--- a/versioned_docs/version-2.12/docs/helm/index.mdx
+++ b/versioned_docs/version-2.12/docs/helm/index.mdx
@@ -11,7 +11,7 @@ Pants has good support for the most common operations for managing Helm charts s
 Please share feedback for what you need to use Pants with your Helm charts by either [opening a GitHub issue](https://github.com/pantsbuild/pants/issues/new/choose) or [joining our Slack](/community/getting-help)!
 :::
 
-# Initial setup
+## Initial setup
 
 First, activate the relevant backend in `pants.toml`:
 
@@ -49,7 +49,7 @@ root_patterns = [
 ]
 ```
 
-## Adding `helm_chart` targets
+### Adding `helm_chart` targets
 
 Helm charts are identified by the presence of a `Chart.yaml` or `Chart.yml` file, which contains relevant metadata about the chart like its name, version, dependencies, etc. To get started quickly you can create a simple `Chart.yaml` file in your sources folder:
 
@@ -72,11 +72,11 @@ Created src/helm/example/BUILD:
   - Add helm_chart target example
 ```
 
-## Basic operations
+### Basic operations
 
 The given setup is enough to now do some common operations on our Helm chart source code.
 
-### Linting
+#### Linting
 
 The Helm backend has an implementation of the Pants' `lint` goal which hooks it with the `helm lint` command:
 
@@ -105,7 +105,7 @@ helm_chart(lint_strict=True)
 
 Likewise, in a similar way you could enable strict linting globally and then choose to disable it in a per-target basis. Run `./pants help helm` or `./pants help helm_chart` for more information.
 
-### Package
+#### Package
 
 Packing helm charts is supported out of the box via the Pants' `package` goal. The final package will be saved as a `.tgz` file under the `dist` folder at your source root.
 
@@ -118,7 +118,7 @@ Built Helm chart artifact: testprojects.src.helm.example/example/example-0.2.0.t
 
 The final output folder can customised using the `output_path` field in the `helm_chart` target. Run `./pants help helm_chart` for more information.
 
-# Helm Unit tests
+## Helm Unit tests
 
 The Helm backend supports running Helm unit tests via the [Helm `unittest` plugin](https://github.com/quintush/helm-unittest). To run unit tests follow the instructions on how to use that plugin and then create a `BUILD` file in the same folder where your tests live with the following target:
 
@@ -166,13 +166,13 @@ With the test files in places, you can now run `./pants test ::` and Pants will 
 ✓ testprojects/src/helm/example/tests/env-configmap_test.yaml succeeded in 0.75s.
 ```
 
-# Publishing Helm charts
+## Publishing Helm charts
 
 Pants only supports publishing Helm charts to OCI registries, a feature that was made generally available in Helm 3.8.
 
 The publishing is done with Pants' `publish` goal but first you will need to tell Pants what are the possible destination registries where to upload your charts.
 
-## Configuring OCI registries
+### Configuring OCI registries
 
 In a similar way as the `docker_image` target, a `helm_chart` target takes an optional `registries` field whose value is a list of registry endpoints (prefixed by the `oci://` protocol):
 
@@ -220,7 +220,7 @@ helm_chart(
 )
 ```
 
-## Setting a repository name
+### Setting a repository name
 
 When publishing charts into an OCI registry, you most likely will be interested on separating them from other kind of OCI assets (i.e. container images). For doing so you can set a `repository` field in the `helm_chart` target so the chart artifact will be uploaded to the given path:
 
@@ -240,7 +240,7 @@ You can also set a default global repository in `pants.toml` as in the following
 default_registry_repository = "charts"
 ```
 
-# Managing Chart Dependencies
+## Managing Chart Dependencies
 
 Helm charts can depend on other charts, whether first-party charts defined in the same repo, or third-party charts published in a registry. Pants uses this dependency information to know when work needs to be re-run.
 
@@ -248,7 +248,7 @@ Helm charts can depend on other charts, whether first-party charts defined in th
 To benefit from Pants dependency management and inference in your Helm charts, you will need to use `apiVersion: v2` in your `Chart.yaml` file.
 :::
 
-## `Chart.yaml` dependencies
+### `Chart.yaml` dependencies
 
 Pants will automatically infer dependencies from the `Chart.yaml` file.
 
@@ -285,7 +285,7 @@ Then, running `./pants dependencies`on `bar` will list `foo` as a dependency:
 src/helm/foo
 ```
 
-## Explicitly provided dependencies in `BUILD` files
+### Explicitly provided dependencies in `BUILD` files
 
 If you prefer, you can let your BUILD files be the "source of truth" for dependencies, instead of specifying them in `Chart.yaml`:
 
@@ -313,7 +313,7 @@ helm_chart(dependencies=["//src/helm/foo"])
 
 In this case, the `./pants dependencies` command will show the same result and, in addition, Pants will modify its copy of `bar`'s `Chart.yaml` before using it, so that it includes `foo` in its dependency list. Note that Pants will not modify the original copy in your source tree, only the copy it uses in the sandboxed execution environment.
 
-## Third party chart artifacts
+### Third party chart artifacts
 
 Third party charts are provided to Pants using the `helm_artifact` target:
 

--- a/versioned_docs/version-2.12/docs/introduction/welcome-to-pants.mdx
+++ b/versioned_docs/version-2.12/docs/introduction/welcome-to-pants.mdx
@@ -5,11 +5,11 @@
 
 ---
 
-# What is Pants?
+## What is Pants?
 
 Pants is a fast, scalable, user-friendly build and developer workflow system for codebases of all sizes, including yours!
 
-# What does Pants do?
+## What does Pants do?
 
 Pants installs, orchestrates and runs dozens of standard underlying tools - compilers, code generators, dependency resolvers, test runners, linters, formatters, packagers, REPLs and more - composing them into a single stable, hermetic toolchain, and speeding up your workflows via caching and concurrency.
 
@@ -17,13 +17,13 @@ Pants is designed to be easy to adopt, use, and extend. It doesn't require you t
 
 Pants is currently focused on Python, Go, Java, Scala, Shell, and Docker, with more languages and frameworks coming soon. [The Pants community](/community/members) is friendly and helpful, and supported by [Toolchain](https://toolchain.com/), a venture-backed company whose mission is to enable fast, stable, ergonomic developer workflows for everyone.
 
-# Who is Pants for?
+## Who is Pants for?
 
 Pants is useful for repos of all sizes, but is particularly valuable for those containing multiple distinct but interdependent pieces.
 
 Pants works well with (but does not require) a [_monorepo_ architecture](https://blog.pantsbuild.org/the-monorepo-approach-to-code-management/): a codebase containing multiple projects—often using multiple programming languages and frameworks—in a single unified repository. If you want to scale your codebase without breaking it up into multiple disconnected repos, with all the versioning and maintenance headaches that causes, Pants provides the tooling for you to do so effectively.
 
-# What are the main features of Pants?
+## What are the main features of Pants?
 
 Pants is designed for fast, consistent, ergonomic builds. Some noteworthy features include:
 
@@ -36,7 +36,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 - Extensibility and customizability via a plugin API
 - Code introspection features
 
-# Which languages and frameworks does Pants support?
+## Which languages and frameworks does Pants support?
 
 - Pants [ships](page:language-support) with support for [Python](../python/overview/index.mdx), [Go](../go/index.mdx), [Java](../java-and-scala/index.mdx), [Scala](../java-and-scala/index.mdx) and [Shell](../shell/index.mdx).
 - Pants supports a wide range of code generators (such as Thrift, Protobuf, Scrooge and Avro), linters and formatters, and it is easy to add support for new or custom ones
@@ -45,7 +45,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 We're listening to the community for which languages, frameworks and tools we should support next, so let us know about your needs by [opening an issue](https://github.com/pantsbuild/pants/issues/new/choose) on GitHub or [chatting with us](/community/members) about it on the community Slack!
 Pants was designed for extensibility, and we welcome [contributions](../contributions/index.mdx)!
 
-# How does Pants work?
+## How does Pants work?
 
 The core of Pants is its execution engine, which sequences and coordinates all the underlying work. The engine is written in Rust, for performance. The underlying work is performed by executing _rules_, which are typed Python 3 async coroutines for familiarity and simplicity.
 
@@ -53,17 +53,17 @@ The engine is designed so that fine-grained invalidation, concurrency, hermetici
 
 See [here](./how-does-pants-work.mdx) for more details about the Pants engine.
 
-# Is Pants similar to X?
+## Is Pants similar to X?
 
 Pants (v2) is a leap forward in the evolution of build systems, a category that runs from the venerable Make through Ant, Maven, Gradle and SBT, to Bazel, Please, Buck, Pants v1 and others.
 
 Its design leans on ideas and inspiration from these earlier tools, while optimizing not just for speed and correctness, but also for ease of adoption, ease of use and ease of extension, all for real-world use cases at a variety of teams.
 
-# Who uses Pants?
+## Who uses Pants?
 
 Pants is making engineering teams productive and happy at a range of companies and organizations. See a sample of them [here](page:who-uses-pants)!
 
-# Who develops Pants?
+## Who develops Pants?
 
 Pants is an open-source software project, developed at [github.com/pantsbuild/pants](https://github.com/pantsbuild/pants). Pants is released under the [Apache License 2.0](https://github.com/pantsbuild/pants/blob/master/LICENSE).
 

--- a/versioned_docs/version-2.12/docs/using-pants/key-concepts/goals.mdx
+++ b/versioned_docs/version-2.12/docs/using-pants/key-concepts/goals.mdx
@@ -17,7 +17,7 @@ To see the current list of goals, run:
 
 You'll see more goals activated as you activate more [backends](./backends.mdx).
 
-# Running goals
+## Running goals
 
 For example:
 
@@ -44,7 +44,7 @@ Finally, Pants supports running goals in a `--loop`: in this mode, all goals spe
 
 Use `Ctrl+C` to exit the `--loop`.
 
-# Goal arguments
+## Goal arguments
 
 Some simple goals—such as the `roots` goal—do not require arguments. But most goals require some arguments to work on.
 
@@ -67,7 +67,7 @@ TOML                         2        65       14        18       33          0
 Note the single-quotes around the file pattern `'**'`. This is so that your shell doesn't attempt to expand the pattern, but instead passes it unaltered to Pants.
 :::
 
-## File arguments vs. target arguments
+### File arguments vs. target arguments
 
 Goal arguments can be of one of two types:
 
@@ -96,7 +96,7 @@ For example, `./pants list ::` will find every target in your project.
 See [Advanced target selection](../advanced-target-selection.mdx) for alternative techniques to specify which files/targets to run on.
 :::
 
-## Goal options
+### Goal options
 
 Many goals also have [options](./options.mdx) to change how they behave. Every option in Pants can be set via an environment variable, config file, and the command line.
 

--- a/versioned_docs/version-2.12/docs/using-pants/key-concepts/options.mdx
+++ b/versioned_docs/version-2.12/docs/using-pants/key-concepts/options.mdx
@@ -7,7 +7,7 @@ A deep dive into how options may be configured.
 
 ---
 
-# Option scopes
+## Option scopes
 
 Options are partitioned into named _scopes_.
 
@@ -15,7 +15,7 @@ Some systemwide options belong in the _global scope_. For example, the `--level`
 
 Other options belong to a _subsystem scope_. A _subsystem_ is simply a collection of related options, in a scope. For example, the `pytest` subsystem contains options related to [Python's test framework pytest](../../../reference/subsystems/pytest.mdx).
 
-# Setting options
+## Setting options
 
 Every option can be set in the following ways, in order of precedence:
 
@@ -27,7 +27,7 @@ If an option isn't set in one of these ways, it will take on a default value.
 
 You can inspect both the current value and the default value by using `./pants help $scope` or `./pants help-advanced $scope`, e.g. `./pants help global`.
 
-## Command-line flags
+### Command-line flags
 
 Global options are set using an unqualified flag:
 
@@ -41,7 +41,7 @@ Subsystem options are set by providing the flag, with the name prefixed with the
 ./pants --source-root-patterns="['^ext']"
 ```
 
-## Environment variables
+### Environment variables
 
 Global options are set using the environment variable `PANTS_{OPTION_NAME}`:
 
@@ -58,7 +58,7 @@ PANTS_SOURCE_ROOT_PATTERNS="['^ext']" ./pants ...
 
 Note that the scope and option name are upper-cased, and any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `MULTIWORD_NAME`.
 
-## Config file entries
+### Config file entries
 
 Global options are set in the `GLOBAL` section of the config file:
 
@@ -76,7 +76,7 @@ root_patterns = ["/src/python"]
 
 Note that any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `multiword_name`.
 
-### Config file interpolation
+#### Config file interpolation
 
 Environment variables can be interpolated by using the syntax `%(env.ENV_VAR)s`, e.g.:
 
@@ -95,7 +95,7 @@ Additionally, a few special values are pre-populated with the `%(var)s` syntax:
 - `%(pants_distdir)s`: absolute path of the global option `--pants-distdir`, which defaults
   to `{buildroot}/dist/`
 
-# Option types
+## Option types
 
 Every option has a type, and any values you set must be of that type.
 
@@ -109,25 +109,25 @@ The option types are:
 
 A list-valued option may also declare a specific type for its members (e.g., a list of strings, or a list of integers).
 
-## String and integer values
+### String and integer values
 
 Standalone string and integer values are written without quotes. Any quotes will be considered part of the value, after shell escaping.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-intopt=42
 ./pants --scope-stropt=qux
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_INTOPT=42
 PANTS_SCOPE_STROPT=qux
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -135,11 +135,11 @@ intopt = 42
 stropt = "qux"
 ```
 
-## Boolean values
+### Boolean values
 
 Boolean values can be specified using the special strings `true` and `false`. When specifying them via command-line flags you can also use the `--boolopt/--no-boolopt` syntax.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-boolopt=true
@@ -147,24 +147,24 @@ Boolean values can be specified using the special strings `true` and `false`. Wh
 ./pants --no-scope-boolopt
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_BOOLOPT=true
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
 boolopt = true
 ```
 
-## List values
+### List values
 
 List values are parsed as Python list literals, so you must quote string values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-listopt="['foo','bar']"
@@ -176,7 +176,7 @@ You can also leave off the `[]` to _append_ elements. So we can rewrite the abov
 ./pants --scope-listopt=foo --scope-listopt=bar
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_LISTOPT="['foo','bar']"
@@ -188,7 +188,7 @@ Like with command-line flags, you can leave off the `[]` to _append_ elements:
 PANTS_SCOPE_LISTOPT=foo
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -198,7 +198,7 @@ listopt = [
 ]
 ```
 
-### Add/remove semantics
+#### Add/remove semantics
 
 List values have some extra semantics:
 
@@ -248,23 +248,23 @@ listopt.remove = [3, 4]
 But note that this only works in Pants's `.toml` config files, not in environment variables or command-line flags.
 :::
 
-## Dict values
+### Dict values
 
 Dict values are parsed as Python dict literals on the command-line and environment variables, so you must quote string keys and values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-dictopt="{'foo':1,'bar':2}"
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_DICTOPT="{'foo':1,'bar':2}"
 ```
 
-### Config file entries:
+#### Config file entries:
 
 You can use TOML's [nested table features](https://toml.io/en/v1.0.0#inline-table). These are equivalent:
 
@@ -289,7 +289,7 @@ dictopt = """{
 }"""
 ```
 
-### Add/replace semantics
+#### Add/replace semantics
 
 - A value can be preceded by `+`, which will _update_ the value obtained from lower-precedence sources with the entries.
 - Otherwise, the value _replaces_ the one obtained from lower-precendence sources.
@@ -308,7 +308,7 @@ will set the value to `{'foo': 42, 'bar': 2, 'baz': 3}`, and
 
 will set the value to `{'foo': 42, 'baz': 3}`.
 
-# Reading individual option values from files
+## Reading individual option values from files
 
 If an option value is too large or elaborate to use directly, or if you don't want to hard-code
 values directly in `pants.toml`, you can set the value of any option to the string
@@ -343,7 +343,7 @@ do so by `kill`ing it (after using `ps -ef | grep pantsd` to find its pid), or b
 Pants once with `--no-pantsd`.
 :::
 
-# `.pants.rc` file
+## `.pants.rc` file
 
 You can set up personal Pants config files, using the same TOML syntax as `pants.toml`. By default, Pants looks for the paths `/etc/pantsrc`, `~/.pants.rc`, and `.pants.rc` in the repository root.
 

--- a/versioned_docs/version-2.12/docs/using-pants/key-concepts/source-roots.mdx
+++ b/versioned_docs/version-2.12/docs/using-pants/key-concepts/source-roots.mdx
@@ -13,7 +13,7 @@ Go does have a notion of source roots: where your `go.mod` is located. However, 
 Shell does not have any notion of source roots.
 :::
 
-# What are source roots?
+## What are source roots?
 
 Some project layouts use top-level folders for namespace purposes, but have the code live underneath. However, the code's imports will ignore these top-level folders, thanks to mechanisms like the `$PYTHONPATH` and the JVM classpath. _Source roots_ are a generic equivalent of these concepts.
 
@@ -44,7 +44,7 @@ pkgutil.get_data("project.config", "prod.json")
 
 In the example above, `src/python` is a source root. So, when some code says `from project.app import App`, Pants can know that this corresponds to the code in `src/python/project/app.py`.
 
-# Configuring source roots
+## Configuring source roots
 
 There are two ways to configure source roots:
 
@@ -60,7 +60,7 @@ src/python
 src/rust
 ```
 
-## Configuring source roots using patterns
+### Configuring source roots using patterns
 
 You can provide a set of patterns that match your source roots:
 
@@ -85,7 +85,7 @@ You can use `*` as a glob. For example, `root_patterns = ["/src/*"]` would consi
 - `src/java`
 - `src/assets`
 
-### Configuring no source roots
+#### Configuring no source roots
 
 Many projects do not have any top-level folders used for namespacing.
 
@@ -125,7 +125,7 @@ The default value of the `root_patterns` config key is `["/", "src", "src/python
 These capture a range of common cases, including a source root at the root of the repository. If your source roots match these patterns, you don't need to explicitly configure them.
 :::
 
-## Configuring source roots using marker files
+### Configuring source roots using marker files
 
 You can also denote your source roots using specially-named marker files. To do so, first pick a name (or multiple names) to use:
 
@@ -182,15 +182,15 @@ import server.server.app
 from utils.utils.strutil import capitalize
 ```
 
-# Examples
+## Examples
 
 These project structures are all valid; Pants does not expect you to reorganize your codebase to use the tool.
 
-## `src/<lang>` setup
+### `src/<lang>` setup
 
 This setup is common in "polyglot" repositories: i.e. repos with multiple languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -228,7 +228,7 @@ This setup is common in "polyglot" repositories: i.e. repos with multiple langua
 
 While we have tests in a separate source root here, it's also valid to have tests colocated with their src files.
 
-### Example imports:
+#### Example imports:
 
 ```python
 # Python
@@ -242,7 +242,7 @@ import org.pantsbuild.project.App
 import org.pantsbuild.project.util.Math
 ```
 
-### Config:
+#### Config:
 
 ```toml title="pants.toml"
 [source]
@@ -255,9 +255,9 @@ root_patterns = [
 
 Note that we organized our 3rdparty requirements in the top-level folders `3rdparty/python` and `3rdparty/java`, but we do not need to include them as source roots because we do not have any first-party code there.
 
-## Multiple top-level projects
+### Multiple top-level projects
 
-### Project:
+#### Project:
 
 This layout has lots of nesting; this is only one possible way to organize the repository.
 
@@ -289,7 +289,7 @@ This layout has lots of nesting; this is only one possible way to organize the r
         └── spa.js
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 import ads.billing.calculate_bill
@@ -299,7 +299,7 @@ from base.util.math import add_two
 
 Note that even though the projects live in different top-level folders, you are still able to import from other projects. If you would like to limit this, you can use `./pants dependees` or `./pants dependencies` in CI to track where imports are being used. See [Project introspection](../project-introspection.mdx).
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 
@@ -320,11 +320,11 @@ root_patterns = [
 ]
 ```
 
-## No source root
+### No source root
 
 Warning: while this project structure is valid, it often does not scale as well as your codebase grows, such as adding new languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -340,7 +340,7 @@ Warning: while this project structure is valid, it often does not scale as well 
 └── pyproject.toml
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 from project.app import App
@@ -349,7 +349,7 @@ from project.util.math import add_two
 pkgutil.get_data("project.config", "prod.json")
 ```
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 

--- a/versioned_docs/version-2.12/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/versioned_docs/version-2.12/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -23,7 +23,7 @@ To reduce boilerplate, some targets also generate other targets:
 - `shell_sources` -> `shell_source`
 - `go_mod` -> `go_third_party_package`
 
-# BUILD files
+## BUILD files
 
 Targets are defined in files with the name `BUILD`. For example:
 
@@ -45,7 +45,7 @@ All target types have a `name` field, which is used to identify the target. Targ
 
 Use [`./pants tailor`](../../getting-started/initial-configuration.mdx#5-generate-build-files) to automate generating BUILD files, and [`./pants update-build-files`](../../../reference/goals/update-build-files.mdx) to reformat them (using `black`, [by default](../../../reference/goals/update-build-files.mdx#section-formatter)).
 
-# Target addresses
+## Target addresses
 
 A target is identified by its unique address, in the form `path/to/dir:name`. The above example has the addresses `helloworld/greet:tests` and `helloworld/greet:bin`.
 
@@ -68,7 +68,7 @@ You can refer to this target with either `helloworld/greet:greet` or the abbrevi
 Addressed defined in the `BUILD` file at the root of your repository are prefixed with `//`, e.g. `//:my_tgt`.
 :::
 
-# `source` and `sources` field
+## `source` and `sources` field
 
 Targets like `python_test` and `resource` have a `source: str` field, while target generators like `python_tests` and `resources` have a `sources: list[str]` field. This determines which source files belong to the target.
 
@@ -108,7 +108,7 @@ Including the same file in the `source` / `sources` field for multiple targets c
 You can run `./pants list path/to/file.ext` to see all "owning" targets to check if >1 target has the file in its `source` field.
 :::
 
-# `dependencies` field
+## `dependencies` field
 
 A target's dependencies determines which other first-party code and third-party requirements to include when building the target.
 
@@ -151,7 +151,7 @@ You can use the prefix `!!` to transitively exclude a dependency, meaning that e
 Transitive excludes can only be used in target types that conventionally are not dependend upon by other targets, such as `pex_binary` and `python_test` / `python_tests`. This is meant to limit confusion, as using `!!` in something like a `python_source` / `python_sources` target could result in surprising behavior for everything that depends on it. (Pants will print a helpful error when using `!!` when it's not legal.)
 :::
 
-# Target generation
+## Target generation
 
 To reduce boilerplate, Pants provides target types that generate other targets. For example:
 
@@ -209,7 +209,7 @@ It's useful for metadata to be as fine-grained as feasible, such as by using the
 [`./pants tailor`](../../getting-started/initial-configuration.mdx#5-generate-build-files) will automatically create targets that only apply metadata for the directory.
 :::
 
-# Parametrizing targets
+## Parametrizing targets
 
 It can be useful to create multiple targets describing the same entity, each with different metadata. For example:
 

--- a/versioned_docs/version-2.12/docs/using-pants/remote-caching-&-execution/index.mdx
+++ b/versioned_docs/version-2.12/docs/using-pants/remote-caching-&-execution/index.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Overview
+## Overview
 
 Ordinarily, Pants executes processes locally on the system on which it is run and also caches the results of those processes locally as well. Besides this "local execution" mode of operation, Pants also supports two distributed modes of operation:
 
@@ -15,7 +15,7 @@ Ordinarily, Pants executes processes locally on the system on which it is run an
 
 Pants does this by using the "Remote Execution API" to converse with the remote cache or remote execution server.
 
-## What is Remote Execution API?
+### What is Remote Execution API?
 
 Pants is compatible with remote caching and remote execution servers that comply with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI protocol is supported by several different server and client projects including Bazel and of course Pants.
 
@@ -27,7 +27,7 @@ Pants calls the CAS a "store server" and the execution service an "execution ser
 
 The REAPI model contains the notion of an "instance." An "instance" is a distinct deployment of a CAS and/or execution service that is given a specific name. All REAPI operations send an instance name to the server, thus a single network endpoint can conceivably support multiple REAPI deployments.
 
-# Server compatibility
+## Server compatibility
 
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
@@ -37,6 +37,6 @@ In order to use remote caching or remote execution, Pants will need access to a 
 
 **Note**: Setup of a remote execution server is beyond the scope of this documentation. All three server projects have support channels on the BuildTeamWorld Slack. [Go here to obtain an invite to that Slack.](https://bit.ly/2SG1amT)
 
-# Resources
+## Resources
 
 - The [remote-apis-testing project](https://gitlab.com/remote-apis-testing/remote-apis-testing) maintains a compatibility test suite of the various server and client implementations of REAPI.

--- a/versioned_docs/version-2.12/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
+++ b/versioned_docs/version-2.12/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
@@ -5,17 +5,17 @@
 
 ---
 
-# What is remote caching?
+## What is remote caching?
 
 Remote caching allows Pants to store and retrieve the results of process execution to and from a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"), rather than only using your machine's local Pants cache. This allows Pants to share a cache across different runs and different machines, for example, all of your CI workers sharing the same fine-grained cache.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote caching requires the availability of a REAPI-compatible cache. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants Configuration
+### Pants Configuration
 
 After you have either set up a REAPI cache server or obtained access to one, the next step is to point Pants to it so that Pants will use it to read and write process results.
 
@@ -31,6 +31,6 @@ remote_instance_name = "main"
 
 If the endpoint is using TLS, then the `remote_store_address` option would be specified with the `grpcs://` scheme, i.e. `"grpcs://cache.corp.example.com:8980"`.
 
-# Reference
+## Reference
 
 Run `./pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.

--- a/versioned_docs/version-2.12/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
+++ b/versioned_docs/version-2.12/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
@@ -9,17 +9,17 @@
 Remote execution support in Pants comes with several limitations. For example, Pants requires that the server's operating system match the client's operating system. In practice, this means that Pants must be running on Linux because all three major server projects generally only operate on Linux.
 :::
 
-# What is remote execution?
+## What is remote execution?
 
 "Remote execution" allows Pants to offload execution of processes to a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI standard is supported by several different server and client projects including Bazel and of course Pants.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote execution requires the availability of a REAPI-compatible execution server. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants
+### Pants
 
 After you have either set up a REAPI server or obtained access to one, the next step is to point Pants to it so that Pants may submit REAPI execution requests. The server should be running a CAS and execution service. These may be the same network endpoint, but for Pants' purposes, they are configured by different configuration options.
 
@@ -33,7 +33,7 @@ remote_execution_address = "grpc://build.corp.example.com:8980"
 remote_instance_name = "main"
 ```
 
-### Platform Properties
+#### Platform Properties
 
 The REAPI execution service selects a worker for a process by consulting the "platform properties" that are passed in a remote execution request. These platform properties are key/value pairs that are configured in the server. Generally, you will configure these in the server (or be provided them by your server's administrator), and then configure Pants to use what was configured.
 
@@ -50,7 +50,7 @@ remote_execution_extra_platform_properties = [
 ]
 ```
 
-### Concurrency
+#### Concurrency
 
 Finally, you should configure Pants to limit the number of concurrent execution requests that are sent to the REAPI server. The `process_execution_remote_parallelism` option controls this concurrency. For example, if `process_execution_remote_parallelism` is set to `20`, then Pants will only send a maximum of 20 execution requests at a single moment of time.
 
@@ -70,7 +70,7 @@ remote_execution_extra_platform_properties = [
 process_execution_remote_parallelism = 20
 ```
 
-### TLS
+#### TLS
 
 You can enable TLS by prefixing the `remote_store_address` and `remote_execution_address` with `grpcs://` instead of `grpc://`.
 
@@ -88,11 +88,11 @@ remote_instance_name = "main"
 remote_ca_certs_path = "/etc/ssl/certs/ca-certificates.crt"
 ```
 
-# Reference
+## Reference
 
 Run `./pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.
 
-# Limitations
+## Limitations
 
 The remote execution support in Pants is still experimental and comes with several limitations:
 

--- a/versioned_docs/version-2.13/docs/contributions/development/internal-architecture.mdx
+++ b/versioned_docs/version-2.13/docs/contributions/development/internal-architecture.mdx
@@ -5,9 +5,9 @@
 
 ---
 
-# Rule Graph Construction
+## Rule Graph Construction
 
-## Overview
+### Overview
 
 Build logic in [Pants](https://www.pantsbuild.org/) is declared using collections of `@rules` with recursively memoized and invalidated results. This framework (known as Pants' "Engine") has similar goals to Bazel's [Skyframe](https://bazel.build/designs/skyframe.html) and the [Salsa](https://github.com/salsa-rs/salsa) framework: users define logic using a particular API, and the framework manages tracking the dependencies between nodes in a runtime graph.
 
@@ -15,11 +15,11 @@ In order to maximize the amount of work that can be reused at runtime, Pants sta
 
 Concepts used in compilers, including live variable analysis and monomorphization, can also be useful in rule graph construction to minimize rule identities and pre-decide which versions of their dependencies they will use.
 
-## Concepts
+### Concepts
 
 A successfully constructed `RuleGraph` contains a graph where nodes have one of three types, `Rule`s, `Query`s, and `Param`s, which map fairly closely to what a Pants `@rule` author consumes. The edges between nodes represent dependencies: `Query`s are always roots of the graph, `Param`s are always leaves, and `Rule`s represent the end user logic making up all of the internal nodes of the graph.
 
-### Rules
+#### Rules
 
 A `Rule` is a function or coroutine with all of its inputs declared as part of its type signature. The end user type signature is made up of:
 
@@ -31,13 +31,13 @@ In the `RuleGraph`, these are encoded in a [Rule](https://github.com/pantsbuild/
 
 `Rule`s never refer to one another by name (i.e., they do not call one another by name): instead, their signature declares their requirements in terms of input/output types, and rule graph construction decides which potential dependencies will provide those requirements.
 
-### Queries
+#### Queries
 
 The roots/entrypoints of a `RuleGraph` are `Query`s, which should correspond one-to-one to external callsites that use the engine to request that values are computed. A `Query` has an output type, and a series of input types: `Query(output_type, (*input_types))`.
 
 If a user makes a request to the engine that does not have a corresponding `Query` declared, the engine fails rather than attempting to dynamically determine which `Rules` to use to answer the `Query`: how a `RuleGraph` is constructed should show why that is the case.
 
-### Params
+#### Params
 
 `Params` are typed, comparable (`eq`/`hash`) values that represent both the inputs to `Rules`, and the building block of the runtime memoization key for a `Rule`. The set of `Params` (unique by type) that are consumed to create a `Rule`'s inputs (plus the `Rule`'s own identity) make up the memoization key for a runtime instance of the `Rule`.
 
@@ -47,7 +47,7 @@ The `Param`s that are available to a `Rule` are made available by the `Rule`'s d
 
 `Params` flow down the graph from `Query`s and the provided `Param`s of `Get`s: their presence does not need to be re-declared at each intermediate callsite. When a `Rule` consumes a `Param` as a positional argument, that `Param` will no longer be available to that `Rule`'s dependencies (but it might still be present in other subgraphs adjacent to that `Rule`).
 
-## Goals
+### Goals
 
 The goals of `RuleGraph` construction are:
 
@@ -61,7 +61,7 @@ If either of the goals were removed, `RuleGraph` construction might be more stra
 
 But both of the goals are important because together they allow for an API that is easy to write `Rule`s for, with minimal boilerplate required to get the inputs needed for a `Rule` to compute a value, and minimal invalidation. Because the identity of a `Rule` is computed from its transitive input `Param`s rather than from its positional arguments, `Rule`s can accept arbitrarily-many large input values (which don't need to implement hash) with no impact on its memoization hit rate.
 
-## Constraints
+### Constraints
 
 There are a few constraints that decide which `Rule`s are able to provide dependencies for one another:
 
@@ -71,7 +71,7 @@ There are a few constraints that decide which `Rule`s are able to provide depend
 - `provided_params` - When deciding whether one `Rule` can use another `Rule` to provide the output type of a `Get`, a constraint is applied that the candidate depedency must (transitively) consume the `Param` that is provided by the `Get`.
   - For example: if a `Rule` `z` has a `Get(A, B)`, only `Rule`s that compute an `A` and (transitively) consume a `B` are eligible to be used. This also means that a `Param` `A` which is already in scope for `Rule` `z` is not eligible to be used, because it would trivially not consume `B`.
 
-## Implementation
+### Implementation
 
 As of [3a188a1e06](https://github.com/pantsbuild/pants/blob/3a188a1e06d8c27ff86d8c311ff1b2bdea0d39ff/src/rust/engine/rule_graph/src/builder.rs#L202-L219), we construct a `RuleGraph` using a combination of data flow analysis and some homegrown (and likely problematic: see the "Issue Overview") node splitting on the call graph of `Rule`s.
 

--- a/versioned_docs/version-2.13/docs/helm/index.mdx
+++ b/versioned_docs/version-2.13/docs/helm/index.mdx
@@ -11,7 +11,7 @@ Pants has good support for the most common operations for managing Helm charts s
 Please share feedback for what you need to use Pants with your Helm charts by either [opening a GitHub issue](https://github.com/pantsbuild/pants/issues/new/choose) or [joining our Slack](/community/getting-help)!
 :::
 
-# Initial setup
+## Initial setup
 
 First, activate the relevant backend in `pants.toml`:
 
@@ -49,7 +49,7 @@ root_patterns = [
 ]
 ```
 
-## Adding `helm_chart` targets
+### Adding `helm_chart` targets
 
 Helm charts are identified by the presence of a `Chart.yaml` or `Chart.yml` file, which contains relevant metadata about the chart like its name, version, dependencies, etc. To get started quickly you can create a simple `Chart.yaml` file in your sources folder:
 
@@ -72,11 +72,11 @@ Created src/helm/example/BUILD:
   - Add helm_chart target example
 ```
 
-## Basic operations
+### Basic operations
 
 The given setup is enough to now do some common operations on our Helm chart source code.
 
-### Linting
+#### Linting
 
 The Helm backend has an implementation of the Pants' `lint` goal which hooks it with the `helm lint` command:
 
@@ -107,7 +107,7 @@ Likewise, in a similar way you could enable strict linting globally and then cho
 
 You can set the field `skip_lint=True` on each `helm_chart` target to avoid linting it.
 
-### Package
+#### Package
 
 Packing helm charts is supported out of the box via the Pants' `package` goal. The final package will be saved as a `.tgz` file under the `dist` folder at your source root.
 
@@ -120,7 +120,7 @@ Built Helm chart artifact: testprojects.src.helm.example/example/example-0.2.0.t
 
 The final output folder can customised using the `output_path` field in the `helm_chart` target. Run `./pants help helm_chart` for more information.
 
-# Helm Unit tests
+## Helm Unit tests
 
 The Helm backend supports running Helm unit tests via the [Helm `unittest` plugin](https://github.com/quintush/helm-unittest). To run unit tests follow the instructions on how to use that plugin and then create a `BUILD` file in the same folder where your tests live with the following target:
 
@@ -168,13 +168,13 @@ With the test files in places, you can now run `./pants test ::` and Pants will 
 ✓ testprojects/src/helm/example/tests/env-configmap_test.yaml succeeded in 0.75s.
 ```
 
-# Publishing Helm charts
+## Publishing Helm charts
 
 Pants only supports publishing Helm charts to OCI registries, a feature that was made generally available in Helm 3.8.
 
 The publishing is done with Pants' `publish` goal but first you will need to tell Pants what are the possible destination registries where to upload your charts.
 
-## Configuring OCI registries
+### Configuring OCI registries
 
 In a similar way as the `docker_image` target, a `helm_chart` target takes an optional `registries` field whose value is a list of registry endpoints (prefixed by the `oci://` protocol):
 
@@ -222,7 +222,7 @@ helm_chart(
 )
 ```
 
-## Setting a repository name
+### Setting a repository name
 
 When publishing charts into an OCI registry, you most likely will be interested on separating them from other kind of OCI assets (i.e. container images). For doing so you can set a `repository` field in the `helm_chart` target so the chart artifact will be uploaded to the given path:
 
@@ -242,7 +242,7 @@ You can also set a default global repository in `pants.toml` as in the following
 default_registry_repository = "charts"
 ```
 
-# Managing Chart Dependencies
+## Managing Chart Dependencies
 
 Helm charts can depend on other charts, whether first-party charts defined in the same repo, or third-party charts published in a registry. Pants uses this dependency information to know when work needs to be re-run.
 
@@ -250,7 +250,7 @@ Helm charts can depend on other charts, whether first-party charts defined in th
 To benefit from Pants dependency management and inference in your Helm charts, you will need to use `apiVersion: v2` in your `Chart.yaml` file.
 :::
 
-## `Chart.yaml` dependencies
+### `Chart.yaml` dependencies
 
 Pants will automatically infer dependencies from the `Chart.yaml` file.
 
@@ -287,7 +287,7 @@ Then, running `./pants dependencies`on `bar` will list `foo` as a dependency:
 src/helm/foo
 ```
 
-## Explicitly provided dependencies in `BUILD` files
+### Explicitly provided dependencies in `BUILD` files
 
 If you prefer, you can let your BUILD files be the "source of truth" for dependencies, instead of specifying them in `Chart.yaml`:
 
@@ -315,7 +315,7 @@ helm_chart(dependencies=["//src/helm/foo"])
 
 In this case, the `./pants dependencies` command will show the same result and, in addition, Pants will modify its copy of `bar`'s `Chart.yaml` before using it, so that it includes `foo` in its dependency list. Note that Pants will not modify the original copy in your source tree, only the copy it uses in the sandboxed execution environment.
 
-## Third party chart artifacts
+### Third party chart artifacts
 
 Third party charts are provided to Pants using the `helm_artifact` target:
 

--- a/versioned_docs/version-2.13/docs/introduction/welcome-to-pants.mdx
+++ b/versioned_docs/version-2.13/docs/introduction/welcome-to-pants.mdx
@@ -5,11 +5,11 @@
 
 ---
 
-# What is Pants?
+## What is Pants?
 
 Pants is a fast, scalable, user-friendly build and developer workflow system for codebases of all sizes, including yours!
 
-# What does Pants do?
+## What does Pants do?
 
 Pants installs, orchestrates and runs dozens of standard underlying tools - compilers, code generators, dependency resolvers, test runners, linters, formatters, packagers, REPLs and more - composing them into a single stable, hermetic toolchain, and speeding up your workflows via caching and concurrency.
 
@@ -17,13 +17,13 @@ Pants is designed to be easy to adopt, use, and extend. It doesn't require you t
 
 Pants is currently focused on Python, Go, Java, Scala, Shell, and Docker, with more languages and frameworks coming soon. [The Pants community](/community/members) is friendly and helpful, and supported by [Toolchain](https://toolchain.com/), a venture-backed company whose mission is to enable fast, stable, ergonomic developer workflows for everyone.
 
-# Who is Pants for?
+## Who is Pants for?
 
 Pants is useful for repos of all sizes, but is particularly valuable for those containing multiple distinct but interdependent pieces.
 
 Pants works well with (but does not require) a [_monorepo_ architecture](https://blog.pantsbuild.org/the-monorepo-approach-to-code-management/): a codebase containing multiple projects—often using multiple programming languages and frameworks—in a single unified repository. If you want to scale your codebase without breaking it up into multiple disconnected repos, with all the versioning and maintenance headaches that causes, Pants provides the tooling for you to do so effectively.
 
-# What are the main features of Pants?
+## What are the main features of Pants?
 
 Pants is designed for fast, consistent, ergonomic builds. Some noteworthy features include:
 
@@ -36,7 +36,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 - Extensibility and customizability via a plugin API
 - Code introspection features
 
-# Which languages and frameworks does Pants support?
+## Which languages and frameworks does Pants support?
 
 - Pants [ships](page:language-support) with support for [Python](../python/overview/index.mdx), [Go](../go/index.mdx), [Java](../java-and-scala/index.mdx), [Scala](../java-and-scala/index.mdx) and [Shell](../shell/index.mdx).
 - Pants supports a wide range of code generators (such as Thrift, Protobuf, Scrooge and Avro), linters and formatters, and it is easy to add support for new or custom ones
@@ -45,7 +45,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 We're listening to the community for which languages, frameworks and tools we should support next, so let us know about your needs by [opening an issue](https://github.com/pantsbuild/pants/issues/new/choose) on GitHub or [chatting with us](/community/members) about it on the community Slack!
 Pants was designed for extensibility, and we welcome [contributions](../contributions/index.mdx)!
 
-# How does Pants work?
+## How does Pants work?
 
 The core of Pants is its execution engine, which sequences and coordinates all the underlying work. The engine is written in Rust, for performance. The underlying work is performed by executing _rules_, which are typed Python 3 async coroutines for familiarity and simplicity.
 
@@ -53,17 +53,17 @@ The engine is designed so that fine-grained invalidation, concurrency, hermetici
 
 See [here](./how-does-pants-work.mdx) for more details about the Pants engine.
 
-# Is Pants similar to X?
+## Is Pants similar to X?
 
 Pants (v2) is a leap forward in the evolution of build systems, a category that runs from the venerable Make through Ant, Maven, Gradle and SBT, to Bazel, Please, Buck, Pants v1 and others.
 
 Its design leans on ideas and inspiration from these earlier tools, while optimizing not just for speed and correctness, but also for ease of adoption, ease of use and ease of extension, all for real-world use cases at a variety of teams.
 
-# Who uses Pants?
+## Who uses Pants?
 
 Pants is making engineering teams productive and happy at a range of companies and organizations. See a sample of them [here](page:who-uses-pants)!
 
-# Who develops Pants?
+## Who develops Pants?
 
 Pants is an open-source software project, developed at [github.com/pantsbuild/pants](https://github.com/pantsbuild/pants). Pants is released under the [Apache License 2.0](https://github.com/pantsbuild/pants/blob/master/LICENSE).
 

--- a/versioned_docs/version-2.13/docs/using-pants/key-concepts/goals.mdx
+++ b/versioned_docs/version-2.13/docs/using-pants/key-concepts/goals.mdx
@@ -17,7 +17,7 @@ To see the current list of goals, run:
 
 You'll see more goals activated as you activate more [backends](./backends.mdx).
 
-# Running goals
+## Running goals
 
 For example:
 
@@ -49,7 +49,7 @@ sequentially, and then Pants will wait until a relevant file has changed to try 
 
 Use `Ctrl+C` to exit the `--loop`.
 
-# Goal arguments
+## Goal arguments
 
 Most goals require arguments to know what to work on.
 
@@ -76,7 +76,7 @@ This will become the default in Pants 2.14.
 See [Advanced target selection](../advanced-target-selection.mdx) for alternative techniques to specify which files/targets to run on.
 :::
 
-## Goal options
+### Goal options
 
 Many goals also have [options](./options.mdx) to change how they behave. Every option in Pants can be set via an environment variable, config file, and the command line.
 

--- a/versioned_docs/version-2.13/docs/using-pants/key-concepts/options.mdx
+++ b/versioned_docs/version-2.13/docs/using-pants/key-concepts/options.mdx
@@ -7,7 +7,7 @@ A deep dive into how options may be configured.
 
 ---
 
-# Option scopes
+## Option scopes
 
 Options are partitioned into named _scopes_.
 
@@ -15,7 +15,7 @@ Some systemwide options belong in the _global scope_. For example, the `--level`
 
 Other options belong to a _subsystem scope_. A _subsystem_ is simply a collection of related options, in a scope. For example, the `pytest` subsystem contains options related to [Python's test framework pytest](../../../reference/subsystems/pytest.mdx).
 
-# Setting options
+## Setting options
 
 Every option can be set in the following ways, in order of precedence:
 
@@ -27,7 +27,7 @@ If an option isn't set in one of these ways, it will take on a default value.
 
 You can inspect both the current value and the default value by using `./pants help $scope` or `./pants help-advanced $scope`, e.g. `./pants help global`.
 
-## Command-line flags
+### Command-line flags
 
 Global options are set using an unqualified flag:
 
@@ -41,7 +41,7 @@ Subsystem options are set by providing the flag, with the name prefixed with the
 ./pants --source-root-patterns="['^ext']"
 ```
 
-## Environment variables
+### Environment variables
 
 Global options are set using the environment variable `PANTS_{OPTION_NAME}`:
 
@@ -58,7 +58,7 @@ PANTS_SOURCE_ROOT_PATTERNS="['^ext']" ./pants ...
 
 Note that the scope and option name are upper-cased, and any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `MULTIWORD_NAME`.
 
-## Config file entries
+### Config file entries
 
 Global options are set in the `GLOBAL` section of the config file:
 
@@ -76,7 +76,7 @@ root_patterns = ["/src/python"]
 
 Note that any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `multiword_name`.
 
-### Config file interpolation
+#### Config file interpolation
 
 Environment variables can be interpolated by using the syntax `%(env.ENV_VAR)s`, e.g.:
 
@@ -95,7 +95,7 @@ Additionally, a few special values are pre-populated with the `%(var)s` syntax:
 - `%(pants_distdir)s`: absolute path of the global option `--pants-distdir`, which defaults  
    to `{buildroot}/dist/`
 
-# Option types
+## Option types
 
 Every option has a type, and any values you set must be of that type.
 
@@ -109,25 +109,25 @@ The option types are:
 
 A list-valued option may also declare a specific type for its members (e.g., a list of strings, or a list of integers).
 
-## String and integer values
+### String and integer values
 
 Standalone string and integer values are written without quotes. Any quotes will be considered part of the value, after shell escaping.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-intopt=42
 ./pants --scope-stropt=qux
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_INTOPT=42
 PANTS_SCOPE_STROPT=qux
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -135,11 +135,11 @@ intopt = 42
 stropt = "qux"
 ```
 
-## Boolean values
+### Boolean values
 
 Boolean values can be specified using the special strings `true` and `false`. When specifying them via command-line flags you can also use the `--boolopt/--no-boolopt` syntax.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-boolopt=true
@@ -147,24 +147,24 @@ Boolean values can be specified using the special strings `true` and `false`. Wh
 ./pants --no-scope-boolopt
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_BOOLOPT=true
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
 boolopt = true
 ```
 
-## List values
+### List values
 
 List values are parsed as Python list literals, so you must quote string values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-listopt="['foo','bar']"
@@ -176,7 +176,7 @@ You can also leave off the `[]` to _append_ elements. So we can rewrite the abov
 ./pants --scope-listopt=foo --scope-listopt=bar
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_LISTOPT="['foo','bar']"
@@ -188,7 +188,7 @@ Like with command-line flags, you can leave off the `[]` to _append_ elements:
 PANTS_SCOPE_LISTOPT=foo
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -198,7 +198,7 @@ listopt = [
 ]
 ```
 
-### Add/remove semantics
+#### Add/remove semantics
 
 List values have some extra semantics:
 
@@ -248,23 +248,23 @@ listopt.remove = [3, 4]
 But note that this only works in Pants's `.toml` config files, not in environment variables or command-line flags.
 :::
 
-## Dict values
+### Dict values
 
 Dict values are parsed as Python dict literals on the command-line and environment variables, so you must quote string keys and values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-dictopt="{'foo':1,'bar':2}"
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_DICTOPT="{'foo':1,'bar':2}"
 ```
 
-### Config file entries:
+#### Config file entries:
 
 You can use TOML's [nested table features](https://toml.io/en/v1.0.0#inline-table). These are equivalent:
 
@@ -289,7 +289,7 @@ dictopt = """{
 }"""
 ```
 
-### Add/replace semantics
+#### Add/replace semantics
 
 - A value can be preceded by `+`, which will _update_ the value obtained from lower-precedence sources with the entries.
 - Otherwise, the value _replaces_ the one obtained from lower-precendence sources.
@@ -308,7 +308,7 @@ will set the value to `{'foo': 42, 'bar': 2, 'baz': 3}`, and
 
 will set the value to `{'foo': 42, 'baz': 3}`.
 
-# Reading individual option values from files
+## Reading individual option values from files
 
 If an option value is too large or elaborate to use directly, or if you don't want to hard-code  
 values directly in `pants.toml`, you can set the value of any option to the string  
@@ -343,7 +343,7 @@ do so by `kill`ing it (after using `ps -ef | grep pantsd` to find its pid), or b
 Pants once with `--no-pantsd`.
 :::
 
-# `.pants.rc` file
+## `.pants.rc` file
 
 You can set up personal Pants config files, using the same TOML syntax as `pants.toml`. By default, Pants looks for the paths `/etc/pantsrc`, `~/.pants.rc`, and `.pants.rc` in the repository root.
 

--- a/versioned_docs/version-2.13/docs/using-pants/key-concepts/source-roots.mdx
+++ b/versioned_docs/version-2.13/docs/using-pants/key-concepts/source-roots.mdx
@@ -13,7 +13,7 @@ Go does have a notion of source roots: where your `go.mod` is located. However, 
 Shell does not have any notion of source roots.
 :::
 
-# What are source roots?
+## What are source roots?
 
 Some project layouts use top-level folders for namespace purposes, but have the code live underneath. However, the code's imports will ignore these top-level folders, thanks to mechanisms like the `$PYTHONPATH` and the JVM classpath. _Source roots_ are a generic equivalent of these concepts.
 
@@ -44,7 +44,7 @@ pkgutil.get_data("project.config", "prod.json")
 
 In the example above, `src/python` is a source root. So, when some code says `from project.app import App`, Pants can know that this corresponds to the code in `src/python/project/app.py`.
 
-# Configuring source roots
+## Configuring source roots
 
 There are two ways to configure source roots:
 
@@ -60,7 +60,7 @@ src/python
 src/rust
 ```
 
-## Configuring source roots using patterns
+### Configuring source roots using patterns
 
 You can provide a set of patterns that match your source roots:
 
@@ -85,7 +85,7 @@ You can use `*` as a glob. For example, `root_patterns = ["/src/*"]` would consi
 - `src/java`
 - `src/assets`
 
-### Configuring no source roots
+#### Configuring no source roots
 
 Many projects do not have any top-level folders used for namespacing.
 
@@ -125,7 +125,7 @@ The default value of the `root_patterns` config key is `["/", "src", "src/python
 These capture a range of common cases, including a source root at the root of the repository. If your source roots match these patterns, you don't need to explicitly configure them.
 :::
 
-## Configuring source roots using marker files
+### Configuring source roots using marker files
 
 You can also denote your source roots using specially-named marker files. To do so, first pick a name (or multiple names) to use:
 
@@ -182,15 +182,15 @@ import server.server.app
 from utils.utils.strutil import capitalize
 ```
 
-# Examples
+## Examples
 
 These project structures are all valid; Pants does not expect you to reorganize your codebase to use the tool.
 
-## `src/<lang>` setup
+### `src/<lang>` setup
 
 This setup is common in "polyglot" repositories: i.e. repos with multiple languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -228,7 +228,7 @@ This setup is common in "polyglot" repositories: i.e. repos with multiple langua
 
 While we have tests in a separate source root here, it's also valid to have tests colocated with their src files.
 
-### Example imports:
+#### Example imports:
 
 ```python
 # Python
@@ -242,7 +242,7 @@ import org.pantsbuild.project.App
 import org.pantsbuild.project.util.Math
 ```
 
-### Config:
+#### Config:
 
 ```toml title="pants.toml"
 [source]
@@ -255,9 +255,9 @@ root_patterns = [
 
 Note that we organized our 3rdparty requirements in the top-level folders `3rdparty/python` and `3rdparty/java`, but we do not need to include them as source roots because we do not have any first-party code there.
 
-## Multiple top-level projects
+### Multiple top-level projects
 
-### Project:
+#### Project:
 
 This layout has lots of nesting; this is only one possible way to organize the repository.
 
@@ -289,7 +289,7 @@ This layout has lots of nesting; this is only one possible way to organize the r
         └── spa.js
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 import ads.billing.calculate_bill
@@ -299,7 +299,7 @@ from base.util.math import add_two
 
 Note that even though the projects live in different top-level folders, you are still able to import from other projects. If you would like to limit this, you can use `./pants dependees` or `./pants dependencies` in CI to track where imports are being used. See [Project introspection](../project-introspection.mdx).
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 
@@ -320,11 +320,11 @@ root_patterns = [
 ]
 ```
 
-## No source root
+### No source root
 
 Warning: while this project structure is valid, it often does not scale as well as your codebase grows, such as adding new languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -340,7 +340,7 @@ Warning: while this project structure is valid, it often does not scale as well 
 └── pyproject.toml
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 from project.app import App
@@ -349,7 +349,7 @@ from project.util.math import add_two
 pkgutil.get_data("project.config", "prod.json")
 ```
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 

--- a/versioned_docs/version-2.13/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/versioned_docs/version-2.13/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -23,7 +23,7 @@ To reduce boilerplate, some targets also generate other targets:
 - `shell_sources` -> `shell_source`
 - `go_mod` -> `go_third_party_package`
 
-# BUILD files
+## BUILD files
 
 Targets are defined in files with the name `BUILD`. For example:
 
@@ -45,7 +45,7 @@ All target types have a `name` field, which is used to identify the target. Targ
 
 Use [`./pants tailor ::`](../../getting-started/initial-configuration.mdx#5-generate-build-files) to automate generating BUILD files, and [`./pants update-build-files ::`](../../../reference/goals/update-build-files.mdx) to reformat them (using `black`, [by default](../../../reference/goals/update-build-files.mdx#section-formatter)).
 
-# Target addresses
+## Target addresses
 
 A target is identified by its unique address, in the form `path/to/dir:name`. The above example has the addresses `helloworld/greet:tests` and `helloworld/greet:bin`.
 
@@ -68,7 +68,7 @@ You can refer to this target with either `helloworld/greet:greet` or the abbrevi
 Addressed defined in the `BUILD` file at the root of your repository are prefixed with `//`, e.g. `//:my_tgt`.
 :::
 
-# `source` and `sources` field
+## `source` and `sources` field
 
 Targets like `python_test` and `resource` have a `source: str` field, while target generators like `python_tests` and `resources` have a `sources: list[str]` field. This determines which source files belong to the target.
 
@@ -108,7 +108,7 @@ Including the same file in the `source` / `sources` field for multiple targets c
 You can run `./pants list path/to/file.ext` to see all "owning" targets to check if >1 target has the file in its `source` field.
 :::
 
-# `dependencies` field
+## `dependencies` field
 
 A target's dependencies determines which other first-party code and third-party requirements to include when building the target.
 
@@ -151,7 +151,7 @@ You can use the prefix `!!` to transitively exclude a dependency, meaning that e
 Transitive excludes can only be used in target types that conventionally are not dependend upon by other targets, such as `pex_binary` and `python_test` / `python_tests`. This is meant to limit confusion, as using `!!` in something like a `python_source` / `python_sources` target could result in surprising behavior for everything that depends on it. (Pants will print a helpful error when using `!!` when it's not legal.)
 :::
 
-# Target generation
+## Target generation
 
 To reduce boilerplate, Pants provides target types that generate other targets. For example:
 
@@ -209,7 +209,7 @@ It's useful for metadata to be as fine-grained as feasible, such as by using the
 [`./pants tailor ::`](../../getting-started/initial-configuration.mdx#5-generate-build-files) will automatically create targets that only apply metadata for the directory.
 :::
 
-# Parametrizing targets
+## Parametrizing targets
 
 It can be useful to create multiple targets describing the same entity, each with different metadata. For example:
 

--- a/versioned_docs/version-2.13/docs/using-pants/remote-caching-&-execution/index.mdx
+++ b/versioned_docs/version-2.13/docs/using-pants/remote-caching-&-execution/index.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Overview
+## Overview
 
 Ordinarily, Pants executes processes locally on the system on which it is run and also caches the results of those processes locally as well. Besides this "local execution" mode of operation, Pants also supports two distributed modes of operation:
 
@@ -15,7 +15,7 @@ Ordinarily, Pants executes processes locally on the system on which it is run an
 
 Pants does this by using the "Remote Execution API" to converse with the remote cache or remote execution server.
 
-## What is Remote Execution API?
+### What is Remote Execution API?
 
 Pants is compatible with remote caching and remote execution servers that comply with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI protocol is supported by several different server and client projects including Bazel and of course Pants.
 
@@ -27,7 +27,7 @@ Pants calls the CAS a "store server" and the execution service an "execution ser
 
 The REAPI model contains the notion of an "instance." An "instance" is a distinct deployment of a CAS and/or execution service that is given a specific name. All REAPI operations send an instance name to the server, thus a single network endpoint can conceivably support multiple REAPI deployments.
 
-# Server compatibility
+## Server compatibility
 
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
@@ -46,6 +46,6 @@ In order to use remote caching or remote execution, Pants will need access to a 
 There are a few [other](https://github.com/bazelbuild/remote-apis) systems and services in this space, but
 they have not, to our knowledge, been tested with Pants. Let us know if you have any experience with them!
 
-# Resources
+## Resources
 
 - The [remote-apis-testing project](https://gitlab.com/remote-apis-testing/remote-apis-testing) maintains a compatibility test suite of the various server and client implementations of REAPI.

--- a/versioned_docs/version-2.13/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
+++ b/versioned_docs/version-2.13/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
@@ -5,17 +5,17 @@
 
 ---
 
-# What is remote caching?
+## What is remote caching?
 
 Remote caching allows Pants to store and retrieve the results of process execution to and from a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"), rather than only using your machine's local Pants cache. This allows Pants to share a cache across different runs and different machines, for example, all of your CI workers sharing the same fine-grained cache.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote caching requires the availability of a REAPI-compatible cache. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants Configuration
+### Pants Configuration
 
 After you have either set up a REAPI cache server or obtained access to one, the next step is to point Pants to it so that Pants will use it to read and write process results.
 
@@ -31,6 +31,6 @@ remote_instance_name = "main"
 
 If the endpoint is using TLS, then the `remote_store_address` option would be specified with the `grpcs://` scheme, i.e. `"grpcs://cache.corp.example.com:8980"`.
 
-# Reference
+## Reference
 
 Run `./pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.

--- a/versioned_docs/version-2.13/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
+++ b/versioned_docs/version-2.13/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
@@ -9,17 +9,17 @@
 Remote execution support in Pants comes with several limitations. For example, Pants requires that the server's operating system match the client's operating system. In practice, this means that Pants must be running on Linux because all three major server projects generally only operate on Linux.
 :::
 
-# What is remote execution?
+## What is remote execution?
 
 "Remote execution" allows Pants to offload execution of processes to a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI standard is supported by several different server and client projects including Bazel and of course Pants.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote execution requires the availability of a REAPI-compatible execution server. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants
+### Pants
 
 After you have either set up a REAPI server or obtained access to one, the next step is to point Pants to it so that Pants may submit REAPI execution requests. The server should be running a CAS and execution service. These may be the same network endpoint, but for Pants' purposes, they are configured by different configuration options.
 
@@ -33,7 +33,7 @@ remote_execution_address = "grpc://build.corp.example.com:8980"
 remote_instance_name = "main"
 ```
 
-### Platform Properties
+#### Platform Properties
 
 The REAPI execution service selects a worker for a process by consulting the "platform properties" that are passed in a remote execution request. These platform properties are key/value pairs that are configured in the server. Generally, you will configure these in the server (or be provided them by your server's administrator), and then configure Pants to use what was configured.
 
@@ -50,7 +50,7 @@ remote_execution_extra_platform_properties = [
 ]
 ```
 
-### Concurrency
+#### Concurrency
 
 Finally, you should configure Pants to limit the number of concurrent execution requests that are sent to the REAPI server. The `process_execution_remote_parallelism` option controls this concurrency. For example, if `process_execution_remote_parallelism` is set to `20`, then Pants will only send a maximum of 20 execution requests at a single moment of time.
 
@@ -70,7 +70,7 @@ remote_execution_extra_platform_properties = [
 process_execution_remote_parallelism = 20
 ```
 
-### TLS
+#### TLS
 
 You can enable TLS by prefixing the `remote_store_address` and `remote_execution_address` with `grpcs://` instead of `grpc://`.
 
@@ -88,11 +88,11 @@ remote_instance_name = "main"
 remote_ca_certs_path = "/etc/ssl/certs/ca-certificates.crt"
 ```
 
-# Reference
+## Reference
 
 Run `./pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.
 
-# Limitations
+## Limitations
 
 The remote execution support in Pants is still experimental and comes with several limitations:
 

--- a/versioned_docs/version-2.14/docs/contributions/development/internal-architecture.mdx
+++ b/versioned_docs/version-2.14/docs/contributions/development/internal-architecture.mdx
@@ -5,9 +5,9 @@
 
 ---
 
-# Rule Graph Construction
+## Rule Graph Construction
 
-## Overview
+### Overview
 
 Build logic in [Pants](https://www.pantsbuild.org/) is declared using collections of `@rules` with recursively memoized and invalidated results. This framework (known as Pants' "Engine") has similar goals to Bazel's [Skyframe](https://bazel.build/designs/skyframe.html) and the [Salsa](https://github.com/salsa-rs/salsa) framework: users define logic using a particular API, and the framework manages tracking the dependencies between nodes in a runtime graph.
 
@@ -15,11 +15,11 @@ In order to maximize the amount of work that can be reused at runtime, Pants sta
 
 Concepts used in compilers, including live variable analysis and monomorphization, can also be useful in rule graph construction to minimize rule identities and pre-decide which versions of their dependencies they will use.
 
-## Concepts
+### Concepts
 
 A successfully constructed `RuleGraph` contains a graph where nodes have one of three types, `Rule`s, `Query`s, and `Param`s, which map fairly closely to what a Pants `@rule` author consumes. The edges between nodes represent dependencies: `Query`s are always roots of the graph, `Param`s are always leaves, and `Rule`s represent the end user logic making up all of the internal nodes of the graph.
 
-### Rules
+#### Rules
 
 A `Rule` is a function or coroutine with all of its inputs declared as part of its type signature. The end user type signature is made up of:
 
@@ -31,13 +31,13 @@ In the `RuleGraph`, these are encoded in a [Rule](https://github.com/pantsbuild/
 
 `Rule`s never refer to one another by name (i.e., they do not call one another by name): instead, their signature declares their requirements in terms of input/output types, and rule graph construction decides which potential dependencies will provide those requirements.
 
-### Queries
+#### Queries
 
 The roots/entrypoints of a `RuleGraph` are `Query`s, which should correspond one-to-one to external callsites that use the engine to request that values are computed. A `Query` has an output type, and a series of input types: `Query(output_type, (*input_types))`.
 
 If a user makes a request to the engine that does not have a corresponding `Query` declared, the engine fails rather than attempting to dynamically determine which `Rules` to use to answer the `Query`: how a `RuleGraph` is constructed should show why that is the case.
 
-### Params
+#### Params
 
 `Params` are typed, comparable (`eq`/`hash`) values that represent both the inputs to `Rules`, and the building block of the runtime memoization key for a `Rule`. The set of `Params` (unique by type) that are consumed to create a `Rule`'s inputs (plus the `Rule`'s own identity) make up the memoization key for a runtime instance of the `Rule`.
 
@@ -47,7 +47,7 @@ The `Param`s that are available to a `Rule` are made available by the `Rule`'s d
 
 `Params` flow down the graph from `Query`s and the provided `Param`s of `Get`s: their presence does not need to be re-declared at each intermediate callsite. When a `Rule` consumes a `Param` as a positional argument, that `Param` will no longer be available to that `Rule`'s dependencies (but it might still be present in other subgraphs adjacent to that `Rule`).
 
-## Goals
+### Goals
 
 The goals of `RuleGraph` construction are:
 
@@ -61,7 +61,7 @@ If either of the goals were removed, `RuleGraph` construction might be more stra
 
 But both of the goals are important because together they allow for an API that is easy to write `Rule`s for, with minimal boilerplate required to get the inputs needed for a `Rule` to compute a value, and minimal invalidation. Because the identity of a `Rule` is computed from its transitive input `Param`s rather than from its positional arguments, `Rule`s can accept arbitrarily-many large input values (which don't need to implement hash) with no impact on its memoization hit rate.
 
-## Constraints
+### Constraints
 
 There are a few constraints that decide which `Rule`s are able to provide dependencies for one another:
 
@@ -71,7 +71,7 @@ There are a few constraints that decide which `Rule`s are able to provide depend
 - `provided_params` - When deciding whether one `Rule` can use another `Rule` to provide the output type of a `Get`, a constraint is applied that the candidate depedency must (transitively) consume the `Param` that is provided by the `Get`.
   - For example: if a `Rule` `z` has a `Get(A, B)`, only `Rule`s that compute an `A` and (transitively) consume a `B` are eligible to be used. This also means that a `Param` `A` which is already in scope for `Rule` `z` is not eligible to be used, because it would trivially not consume `B`.
 
-## Implementation
+### Implementation
 
 As of [3a188a1e06](https://github.com/pantsbuild/pants/blob/3a188a1e06d8c27ff86d8c311ff1b2bdea0d39ff/src/rust/engine/rule_graph/src/builder.rs#L202-L219), we construct a `RuleGraph` using a combination of data flow analysis and some homegrown (and likely problematic: see the "Issue Overview") node splitting on the call graph of `Rule`s.
 

--- a/versioned_docs/version-2.14/docs/helm/index.mdx
+++ b/versioned_docs/version-2.14/docs/helm/index.mdx
@@ -11,7 +11,7 @@ Pants has good support for the most common operations for managing Helm charts s
 Please share feedback for what you need to use Pants with your Helm charts by either [opening a GitHub issue](https://github.com/pantsbuild/pants/issues/new/choose) or [joining our Slack](/community/getting-help)!
 :::
 
-# Initial setup
+## Initial setup
 
 First, activate the relevant backend in `pants.toml`:
 
@@ -40,7 +40,7 @@ name: bar
 version: 0.1.0
 ```
 
-## Adding `helm_chart` targets
+### Adding `helm_chart` targets
 
 Helm charts are identified by the presence of a `Chart.yaml` or `Chart.yml` file, which contains relevant metadata about the chart like its name, version, dependencies, etc. To get started quickly you can create a simple `Chart.yaml` file in your sources folder:
 
@@ -63,11 +63,11 @@ Created src/helm/example/BUILD:
   - Add helm_chart target example
 ```
 
-## Basic operations
+### Basic operations
 
 The given setup is enough to now do some common operations on our Helm chart source code.
 
-### Linting
+#### Linting
 
 The Helm backend has an implementation of the Pants' `lint` goal which hooks it with the `helm lint` command:
 
@@ -98,7 +98,7 @@ Likewise, in a similar way you could enable strict linting globally and then cho
 
 You can set the field `skip_lint=True` on each `helm_chart` target to avoid linting it.
 
-### Package
+#### Package
 
 Packing helm charts is supported out of the box via the Pants' `package` goal. The final package will be saved as a `.tgz` file under the `dist` folder at your source root.
 
@@ -111,7 +111,7 @@ Built Helm chart artifact: testprojects.src.helm.example/example/example-0.2.0.t
 
 The final output folder can customised using the `output_path` field in the `helm_chart` target. Run `./pants help helm_chart` for more information.
 
-# Helm Unit tests
+## Helm Unit tests
 
 The Helm backend supports running Helm unit tests via the [Helm `unittest` plugin](https://github.com/quintush/helm-unittest). To run unit tests follow the instructions on how to use that plugin and then create a `BUILD` file in the same folder where your tests live with the following target:
 
@@ -159,7 +159,7 @@ With the test files in places, you can now run `./pants test ::` and Pants will 
 ✓ testprojects/src/helm/example/tests/env-configmap_test.yaml succeeded in 0.75s.
 ```
 
-### Timeouts
+#### Timeouts
 
 Pants can cancel tests that take too long, which is useful to prevent tests from hanging indefinitely.
 
@@ -193,13 +193,13 @@ If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will 
 
 Use the option `./pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
-# Publishing Helm charts
+## Publishing Helm charts
 
 Pants only supports publishing Helm charts to OCI registries, a feature that was made generally available in Helm 3.8.
 
 The publishing is done with Pants' `publish` goal but first you will need to tell Pants what are the possible destination registries where to upload your charts.
 
-## Configuring OCI registries
+### Configuring OCI registries
 
 In a similar way as the `docker_image` target, a `helm_chart` target takes an optional `registries` field whose value is a list of registry endpoints (prefixed by the `oci://` protocol):
 
@@ -247,7 +247,7 @@ helm_chart(
 )
 ```
 
-## Setting a repository name
+### Setting a repository name
 
 When publishing charts into an OCI registry, you most likely will be interested on separating them from other kind of OCI assets (i.e. container images). For doing so you can set a `repository` field in the `helm_chart` target so the chart artifact will be uploaded to the given path:
 
@@ -267,7 +267,7 @@ You can also set a default global repository in `pants.toml` as in the following
 default_registry_repository = "charts"
 ```
 
-# Managing Chart Dependencies
+## Managing Chart Dependencies
 
 Helm charts can depend on other charts, whether first-party charts defined in the same repo, or third-party charts published in a registry. Pants uses this dependency information to know when work needs to be re-run.
 
@@ -275,7 +275,7 @@ Helm charts can depend on other charts, whether first-party charts defined in th
 To benefit from Pants dependency management and inference in your Helm charts, you will need to use `apiVersion: v2` in your `Chart.yaml` file.
 :::
 
-## `Chart.yaml` dependencies
+### `Chart.yaml` dependencies
 
 Pants will automatically infer dependencies from the `Chart.yaml` file.
 
@@ -312,7 +312,7 @@ Then, running `./pants dependencies`on `bar` will list `foo` as a dependency:
 src/helm/foo
 ```
 
-## Explicitly provided dependencies in `BUILD` files
+### Explicitly provided dependencies in `BUILD` files
 
 If you prefer, you can let your BUILD files be the "source of truth" for dependencies, instead of specifying them in `Chart.yaml`:
 
@@ -340,7 +340,7 @@ helm_chart(dependencies=["//src/helm/foo"])
 
 In this case, the `./pants dependencies` command will show the same result and, in addition, Pants will modify its copy of `bar`'s `Chart.yaml` before using it, so that it includes `foo` in its dependency list. Note that Pants will not modify the original copy in your source tree, only the copy it uses in the sandboxed execution environment.
 
-## Third party chart artifacts
+### Third party chart artifacts
 
 Third party charts are provided to Pants using the `helm_artifact` target:
 

--- a/versioned_docs/version-2.14/docs/introduction/welcome-to-pants.mdx
+++ b/versioned_docs/version-2.14/docs/introduction/welcome-to-pants.mdx
@@ -5,11 +5,11 @@
 
 ---
 
-# What is Pants?
+## What is Pants?
 
 Pants is a fast, scalable, user-friendly build and developer workflow system for codebases of all sizes, including yours!
 
-# What does Pants do?
+## What does Pants do?
 
 Pants installs, orchestrates and runs dozens of standard underlying tools - compilers, code generators, dependency resolvers, test runners, linters, formatters, packagers, REPLs and more - composing them into a single stable, hermetic toolchain, and speeding up your workflows via caching and concurrency.
 
@@ -17,13 +17,13 @@ Pants is designed to be easy to adopt, use, and extend. It doesn't require you t
 
 Pants is currently focused on Python, Go, Java, Scala, Shell, and Docker, with more languages and frameworks coming soon. [The Pants community](/community/members) is friendly and helpful, and supported by [Toolchain](https://toolchain.com/), a venture-backed company whose mission is to enable fast, stable, ergonomic developer workflows for everyone.
 
-# Who is Pants for?
+## Who is Pants for?
 
 Pants is useful for repos of all sizes, but is particularly valuable for those containing multiple distinct but interdependent pieces.
 
 Pants works well with (but does not require) a [_monorepo_ architecture](https://blog.pantsbuild.org/the-monorepo-approach-to-code-management/): a codebase containing multiple projects—often using multiple programming languages and frameworks—in a single unified repository. If you want to scale your codebase without breaking it up into multiple disconnected repos, with all the versioning and maintenance headaches that causes, Pants provides the tooling for you to do so effectively.
 
-# What are the main features of Pants?
+## What are the main features of Pants?
 
 Pants is designed for fast, consistent, ergonomic builds. Some noteworthy features include:
 
@@ -36,7 +36,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 - Extensibility and customizability via a plugin API
 - Code introspection features
 
-# Which languages and frameworks does Pants support?
+## Which languages and frameworks does Pants support?
 
 - Pants [ships](page:language-support) with support for [Python](../python/overview/index.mdx), [Go](../go/index.mdx), [Java](../java-and-scala/index.mdx), [Scala](../java-and-scala/index.mdx) and [Shell](../shell/index.mdx).
 - Pants supports a wide range of code generators (such as Thrift, Protobuf, Scrooge and Avro), linters and formatters, and it is easy to add support for new or custom ones
@@ -45,7 +45,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 We're listening to the community for which languages, frameworks and tools we should support next, so let us know about your needs by [opening an issue](https://github.com/pantsbuild/pants/issues/new/choose) on GitHub or [chatting with us](/community/members) about it on the community Slack!
 Pants was designed for extensibility, and we welcome [contributions](../contributions/index.mdx)!
 
-# How does Pants work?
+## How does Pants work?
 
 The core of Pants is its execution engine, which sequences and coordinates all the underlying work. The engine is written in Rust, for performance. The underlying work is performed by executing _rules_, which are typed Python 3 async coroutines for familiarity and simplicity.
 
@@ -53,17 +53,17 @@ The engine is designed so that fine-grained invalidation, concurrency, hermetici
 
 See [here](./how-does-pants-work.mdx) for more details about the Pants engine.
 
-# Is Pants similar to X?
+## Is Pants similar to X?
 
 Pants (v2) is a leap forward in the evolution of build systems, a category that runs from the venerable Make through Ant, Maven, Gradle and SBT, to Bazel, Please, Buck, Pants v1 and others.
 
 Its design leans on ideas and inspiration from these earlier tools, while optimizing not just for speed and correctness, but also for ease of adoption, ease of use and ease of extension, all for real-world use cases at a variety of teams.
 
-# Who uses Pants?
+## Who uses Pants?
 
 Pants is making engineering teams productive and happy at a range of companies and organizations. See a sample of them [here](page:who-uses-pants)!
 
-# Who develops Pants?
+## Who develops Pants?
 
 Pants is an open-source software project, developed at [github.com/pantsbuild/pants](https://github.com/pantsbuild/pants). Pants is released under the [Apache License 2.0](https://github.com/pantsbuild/pants/blob/master/LICENSE).
 

--- a/versioned_docs/version-2.14/docs/using-pants/key-concepts/goals.mdx
+++ b/versioned_docs/version-2.14/docs/using-pants/key-concepts/goals.mdx
@@ -17,7 +17,7 @@ To see the current list of goals, run:
 
 You'll see more goals activated as you activate more [backends](./backends.mdx).
 
-# Running goals
+## Running goals
 
 For example:
 
@@ -49,7 +49,7 @@ sequentially, and then Pants will wait until a relevant file has changed to try 
 
 Use `Ctrl+C` to exit the `--loop`.
 
-# Goal arguments
+## Goal arguments
 
 Most goals require arguments to know what to work on.
 
@@ -76,7 +76,7 @@ This will become the default in Pants 2.14.
 See [Advanced target selection](../advanced-target-selection.mdx) for alternative techniques to specify which files/targets to run on.
 :::
 
-## Goal options
+### Goal options
 
 Many goals also have [options](./options.mdx) to change how they behave. Every option in Pants can be set via an environment variable, config file, and the command line.
 

--- a/versioned_docs/version-2.14/docs/using-pants/key-concepts/options.mdx
+++ b/versioned_docs/version-2.14/docs/using-pants/key-concepts/options.mdx
@@ -7,7 +7,7 @@ A deep dive into how options may be configured.
 
 ---
 
-# Option scopes
+## Option scopes
 
 Options are partitioned into named _scopes_.
 
@@ -15,7 +15,7 @@ Some systemwide options belong in the _global scope_. For example, the `--level`
 
 Other options belong to a _subsystem scope_. A _subsystem_ is simply a collection of related options, in a scope. For example, the `pytest` subsystem contains options related to [Python's test framework pytest](../../../reference/subsystems/pytest.mdx).
 
-# Setting options
+## Setting options
 
 Every option can be set in the following ways, in order of precedence:
 
@@ -27,7 +27,7 @@ If an option isn't set in one of these ways, it will take on a default value.
 
 You can inspect both the current value and the default value by using `./pants help $scope` or `./pants help-advanced $scope`, e.g. `./pants help global`.
 
-## Command-line flags
+### Command-line flags
 
 Global options are set using an unqualified flag:
 
@@ -41,7 +41,7 @@ Subsystem options are set by providing the flag, with the name prefixed with the
 ./pants --source-root-patterns="['^ext']"
 ```
 
-## Environment variables
+### Environment variables
 
 Global options are set using the environment variable `PANTS_{OPTION_NAME}`:
 
@@ -58,7 +58,7 @@ PANTS_SOURCE_ROOT_PATTERNS="['^ext']" ./pants ...
 
 Note that the scope and option name are upper-cased, and any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `MULTIWORD_NAME`.
 
-## Config file entries
+### Config file entries
 
 Global options are set in the `GLOBAL` section of the config file:
 
@@ -76,7 +76,7 @@ root_patterns = ["/src/python"]
 
 Note that any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `multiword_name`.
 
-### Config file interpolation
+#### Config file interpolation
 
 Environment variables can be interpolated by using the syntax `%(env.ENV_VAR)s`, e.g.:
 
@@ -95,7 +95,7 @@ Additionally, a few special values are pre-populated with the `%(var)s` syntax:
 - `%(pants_distdir)s`: absolute path of the global option `--pants-distdir`, which defaults  
    to `{buildroot}/dist/`
 
-# Option types
+## Option types
 
 Every option has a type, and any values you set must be of that type.
 
@@ -109,25 +109,25 @@ The option types are:
 
 A list-valued option may also declare a specific type for its members (e.g., a list of strings, or a list of integers).
 
-## String and integer values
+### String and integer values
 
 Standalone string and integer values are written without quotes. Any quotes will be considered part of the value, after shell escaping.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-intopt=42
 ./pants --scope-stropt=qux
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_INTOPT=42
 PANTS_SCOPE_STROPT=qux
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -135,11 +135,11 @@ intopt = 42
 stropt = "qux"
 ```
 
-## Boolean values
+### Boolean values
 
 Boolean values can be specified using the special strings `true` and `false`. When specifying them via command-line flags you can also use the `--boolopt/--no-boolopt` syntax.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-boolopt=true
@@ -147,24 +147,24 @@ Boolean values can be specified using the special strings `true` and `false`. Wh
 ./pants --no-scope-boolopt
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_BOOLOPT=true
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
 boolopt = true
 ```
 
-## List values
+### List values
 
 List values are parsed as Python list literals, so you must quote string values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-listopt="['foo','bar']"
@@ -176,7 +176,7 @@ You can also leave off the `[]` to _append_ elements. So we can rewrite the abov
 ./pants --scope-listopt=foo --scope-listopt=bar
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_LISTOPT="['foo','bar']"
@@ -188,7 +188,7 @@ Like with command-line flags, you can leave off the `[]` to _append_ elements:
 PANTS_SCOPE_LISTOPT=foo
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -198,7 +198,7 @@ listopt = [
 ]
 ```
 
-### Add/remove semantics
+#### Add/remove semantics
 
 List values have some extra semantics:
 
@@ -248,23 +248,23 @@ listopt.remove = [3, 4]
 But note that this only works in Pants's `.toml` config files, not in environment variables or command-line flags.
 :::
 
-## Dict values
+### Dict values
 
 Dict values are parsed as Python dict literals on the command-line and environment variables, so you must quote string keys and values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 ./pants --scope-dictopt="{'foo':1,'bar':2}"
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_DICTOPT="{'foo':1,'bar':2}"
 ```
 
-### Config file entries:
+#### Config file entries:
 
 You can use TOML's [nested table features](https://toml.io/en/v1.0.0#inline-table). These are equivalent:
 
@@ -289,7 +289,7 @@ dictopt = """{
 }"""
 ```
 
-### Add/replace semantics
+#### Add/replace semantics
 
 - A value can be preceded by `+`, which will _update_ the value obtained from lower-precedence sources with the entries.
 - Otherwise, the value _replaces_ the one obtained from lower-precendence sources.
@@ -308,7 +308,7 @@ will set the value to `{'foo': 42, 'bar': 2, 'baz': 3}`, and
 
 will set the value to `{'foo': 42, 'baz': 3}`.
 
-# Reading individual option values from files
+## Reading individual option values from files
 
 If an option value is too large or elaborate to use directly, or if you don't want to hard-code  
 values directly in `pants.toml`, you can set the value of any option to the string  
@@ -343,7 +343,7 @@ do so by `kill`ing it (after using `ps -ef | grep pantsd` to find its pid), or b
 Pants once with `--no-pantsd`.
 :::
 
-# `.pants.rc` file
+## `.pants.rc` file
 
 You can set up personal Pants config files, using the same TOML syntax as `pants.toml`. By default, Pants looks for the paths `/etc/pantsrc`, `~/.pants.rc`, and `.pants.rc` in the repository root.
 

--- a/versioned_docs/version-2.14/docs/using-pants/key-concepts/source-roots.mdx
+++ b/versioned_docs/version-2.14/docs/using-pants/key-concepts/source-roots.mdx
@@ -13,7 +13,7 @@ Go does have a notion of source roots: where your `go.mod` is located. However, 
 Shell does not have any notion of source roots.
 :::
 
-# What are source roots?
+## What are source roots?
 
 Some project layouts use top-level folders for namespace purposes, but have the code live underneath. However, the code's imports will ignore these top-level folders, thanks to mechanisms like the `$PYTHONPATH` and the JVM classpath. _Source roots_ are a generic equivalent of these concepts.
 
@@ -44,7 +44,7 @@ pkgutil.get_data("project.config", "prod.json")
 
 In the example above, `src/python` is a source root. So, when some code says `from project.app import App`, Pants can know that this corresponds to the code in `src/python/project/app.py`.
 
-# Configuring source roots
+## Configuring source roots
 
 There are two ways to configure source roots:
 
@@ -60,7 +60,7 @@ src/python
 src/rust
 ```
 
-## Configuring source roots using patterns
+### Configuring source roots using patterns
 
 You can provide a set of patterns that match your source roots:
 
@@ -85,7 +85,7 @@ You can use `*` as a glob. For example, `root_patterns = ["/src/*"]` would consi
 - `src/java`
 - `src/assets`
 
-### Configuring no source roots
+#### Configuring no source roots
 
 Many projects do not have any top-level folders used for namespacing.
 
@@ -125,7 +125,7 @@ The default value of the `root_patterns` config key is `["/", "src", "src/python
 These capture a range of common cases, including a source root at the root of the repository. If your source roots match these patterns, you don't need to explicitly configure them.
 :::
 
-## Configuring source roots using marker files
+### Configuring source roots using marker files
 
 You can also denote your source roots using specially-named marker files. To do so, first pick a name (or multiple names) to use:
 
@@ -182,15 +182,15 @@ import server.server.app
 from utils.utils.strutil import capitalize
 ```
 
-# Examples
+## Examples
 
 These project structures are all valid; Pants does not expect you to reorganize your codebase to use the tool.
 
-## `src/<lang>` setup
+### `src/<lang>` setup
 
 This setup is common in "polyglot" repositories: i.e. repos with multiple languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -228,7 +228,7 @@ This setup is common in "polyglot" repositories: i.e. repos with multiple langua
 
 While we have tests in a separate source root here, it's also valid to have tests colocated with their src files.
 
-### Example imports:
+#### Example imports:
 
 ```python
 # Python
@@ -242,7 +242,7 @@ import org.pantsbuild.project.App
 import org.pantsbuild.project.util.Math
 ```
 
-### Config:
+#### Config:
 
 ```toml title="pants.toml"
 [source]
@@ -255,9 +255,9 @@ root_patterns = [
 
 Note that we organized our 3rdparty requirements in the top-level folders `3rdparty/python` and `3rdparty/java`, but we do not need to include them as source roots because we do not have any first-party code there.
 
-## Multiple top-level projects
+### Multiple top-level projects
 
-### Project:
+#### Project:
 
 This layout has lots of nesting; this is only one possible way to organize the repository.
 
@@ -289,7 +289,7 @@ This layout has lots of nesting; this is only one possible way to organize the r
         └── spa.js
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 import ads.billing.calculate_bill
@@ -299,7 +299,7 @@ from base.util.math import add_two
 
 Note that even though the projects live in different top-level folders, you are still able to import from other projects. If you would like to limit this, you can use `./pants dependees` or `./pants dependencies` in CI to track where imports are being used. See [Project introspection](../project-introspection.mdx).
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 
@@ -320,11 +320,11 @@ root_patterns = [
 ]
 ```
 
-## No source root
+### No source root
 
 Warning: while this project structure is valid, it often does not scale as well as your codebase grows, such as adding new languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -340,7 +340,7 @@ Warning: while this project structure is valid, it often does not scale as well 
 └── pyproject.toml
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 from project.app import App
@@ -349,7 +349,7 @@ from project.util.math import add_two
 pkgutil.get_data("project.config", "prod.json")
 ```
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 

--- a/versioned_docs/version-2.14/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/versioned_docs/version-2.14/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -23,7 +23,7 @@ To reduce boilerplate, some targets also generate other targets:
 - `shell_sources` -> `shell_source`
 - `go_mod` -> `go_third_party_package`
 
-# BUILD files
+## BUILD files
 
 Targets are defined in files with the name `BUILD`. For example:
 
@@ -45,7 +45,7 @@ All target types have a `name` field, which is used to identify the target. Targ
 
 You can autoformat `BUILD` files by enabling a `BUILD` file formatter by adding it to `[GLOBAL].backend_packages` in `pants.toml` (such as `pants.backend.build_files.fmt.black` [or others](./backends.mdx)). Then to format, run `./pants fmt '**/BUILD'` or `./pants fmt ::` (formats everything).
 
-# Target addresses
+## Target addresses
 
 A target is identified by its unique address, in the form `path/to/dir:name`. The above example has the addresses `helloworld/greet:tests` and `helloworld/greet:bin`.
 
@@ -68,7 +68,7 @@ You can refer to this target with either `helloworld/greet:greet` or the abbrevi
 Addressed defined in the `BUILD` file at the root of your repository are prefixed with `//`, e.g. `//:my_tgt`.
 :::
 
-# `source` and `sources` field
+## `source` and `sources` field
 
 Targets like `python_test` and `resource` have a `source: str` field, while target generators like `python_tests` and `resources` have a `sources: list[str]` field. This determines which source files belong to the target.
 
@@ -108,7 +108,7 @@ Including the same file in the `source` / `sources` field for multiple targets c
 You can run `./pants list path/to/file.ext` to see all "owning" targets to check if >1 target has the file in its `source` field.
 :::
 
-# `dependencies` field
+## `dependencies` field
 
 A target's dependencies determines which other first-party code and third-party requirements to include when building the target.
 
@@ -151,7 +151,7 @@ You can use the prefix `!!` to transitively exclude a dependency, meaning that e
 Transitive excludes can only be used in target types that conventionally are not dependend upon by other targets, such as `pex_binary` and `python_test` / `python_tests`. This is meant to limit confusion, as using `!!` in something like a `python_source` / `python_sources` target could result in surprising behavior for everything that depends on it. (Pants will print a helpful error when using `!!` when it's not legal.)
 :::
 
-# Field default values
+## Field default values
 
 As mentioned above in [BUILD files](./targets-and-build-files.mdx#build-files), most fields use sensible defaults. And for specific cases it is easy to provide some other value to a specific target. The issue is if you want to apply a specific non-default value for a field on many targets. This can get unwieldy, error prone and hard to maintain. Enter `__defaults__`.
 
@@ -196,7 +196,7 @@ To reset any modified defaults, simply override with the empty dict:
     __defaults__(all={})
 ```
 
-# Target generation
+## Target generation
 
 To reduce boilerplate, Pants provides target types that generate other targets. For example:
 
@@ -274,7 +274,7 @@ It's useful for metadata to be as fine-grained as feasible, such as by using the
 [`./pants tailor ::`](../../getting-started/initial-configuration.mdx#5-generate-build-files) will automatically create targets that only apply metadata for the directory.
 :::
 
-# Parametrizing targets
+## Parametrizing targets
 
 It can be useful to create multiple targets describing the same entity, each with different metadata. For example:
 

--- a/versioned_docs/version-2.14/docs/using-pants/remote-caching-&-execution/index.mdx
+++ b/versioned_docs/version-2.14/docs/using-pants/remote-caching-&-execution/index.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Overview
+## Overview
 
 Ordinarily, Pants executes processes locally on the system on which it is run and also caches the results of those processes locally as well. Besides this "local execution" mode of operation, Pants also supports two distributed modes of operation:
 
@@ -15,7 +15,7 @@ Ordinarily, Pants executes processes locally on the system on which it is run an
 
 Pants does this by using the "Remote Execution API" to converse with the remote cache or remote execution server.
 
-## What is Remote Execution API?
+### What is Remote Execution API?
 
 Pants is compatible with remote caching and remote execution servers that comply with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI protocol is supported by several different server and client projects including Bazel and of course Pants.
 
@@ -27,7 +27,7 @@ Pants calls the CAS a "store server" and the execution service an "execution ser
 
 The REAPI model contains the notion of an "instance." An "instance" is a distinct deployment of a CAS and/or execution service that is given a specific name. All REAPI operations send an instance name to the server, thus a single network endpoint can conceivably support multiple REAPI deployments.
 
-# Server compatibility
+## Server compatibility
 
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
@@ -46,6 +46,6 @@ In order to use remote caching or remote execution, Pants will need access to a 
 There are a few [other](https://github.com/bazelbuild/remote-apis) systems and services in this space, but
 they have not, to our knowledge, been tested with Pants. Let us know if you have any experience with them!
 
-# Resources
+## Resources
 
 - The [remote-apis-testing project](https://gitlab.com/remote-apis-testing/remote-apis-testing) maintains a compatibility test suite of the various server and client implementations of REAPI.

--- a/versioned_docs/version-2.14/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
+++ b/versioned_docs/version-2.14/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
@@ -5,17 +5,17 @@
 
 ---
 
-# What is remote caching?
+## What is remote caching?
 
 Remote caching allows Pants to store and retrieve the results of process execution to and from a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"), rather than only using your machine's local Pants cache. This allows Pants to share a cache across different runs and different machines, for example, all of your CI workers sharing the same fine-grained cache.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote caching requires the availability of a REAPI-compatible cache. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants Configuration
+### Pants Configuration
 
 After you have either set up a REAPI cache server or obtained access to one, the next step is to point Pants to it so that Pants will use it to read and write process results.
 
@@ -31,6 +31,6 @@ remote_instance_name = "main"
 
 If the endpoint is using TLS, then the `remote_store_address` option would be specified with the `grpcs://` scheme, i.e. `"grpcs://cache.corp.example.com:8980"`.
 
-# Reference
+## Reference
 
 Run `./pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.

--- a/versioned_docs/version-2.14/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
+++ b/versioned_docs/version-2.14/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
@@ -9,17 +9,17 @@
 Remote execution support in Pants comes with several limitations. For example, Pants requires that the server's operating system match the client's operating system. In practice, this means that Pants must be running on Linux because all three major server projects generally only operate on Linux.
 :::
 
-# What is remote execution?
+## What is remote execution?
 
 "Remote execution" allows Pants to offload execution of processes to a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI standard is supported by several different server and client projects including Bazel and of course Pants.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote execution requires the availability of a REAPI-compatible execution server. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants
+### Pants
 
 After you have either set up a REAPI server or obtained access to one, the next step is to point Pants to it so that Pants may submit REAPI execution requests. The server should be running a CAS and execution service. These may be the same network endpoint, but for Pants' purposes, they are configured by different configuration options.
 
@@ -33,7 +33,7 @@ remote_execution_address = "grpc://build.corp.example.com:8980"
 remote_instance_name = "main"
 ```
 
-### Platform Properties
+#### Platform Properties
 
 The REAPI execution service selects a worker for a process by consulting the "platform properties" that are passed in a remote execution request. These platform properties are key/value pairs that are configured in the server. Generally, you will configure these in the server (or be provided them by your server's administrator), and then configure Pants to use what was configured.
 
@@ -50,7 +50,7 @@ remote_execution_extra_platform_properties = [
 ]
 ```
 
-### Concurrency
+#### Concurrency
 
 Finally, you should configure Pants to limit the number of concurrent execution requests that are sent to the REAPI server. The `process_execution_remote_parallelism` option controls this concurrency. For example, if `process_execution_remote_parallelism` is set to `20`, then Pants will only send a maximum of 20 execution requests at a single moment of time.
 
@@ -70,7 +70,7 @@ remote_execution_extra_platform_properties = [
 process_execution_remote_parallelism = 20
 ```
 
-### TLS
+#### TLS
 
 You can enable TLS by prefixing the `remote_store_address` and `remote_execution_address` with `grpcs://` instead of `grpc://`.
 
@@ -88,11 +88,11 @@ remote_instance_name = "main"
 remote_ca_certs_path = "/etc/ssl/certs/ca-certificates.crt"
 ```
 
-# Reference
+## Reference
 
 Run `./pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.
 
-# Limitations
+## Limitations
 
 The remote execution support in Pants is still experimental and comes with several limitations:
 

--- a/versioned_docs/version-2.15/docs/contributions/development/internal-architecture.mdx
+++ b/versioned_docs/version-2.15/docs/contributions/development/internal-architecture.mdx
@@ -5,9 +5,9 @@
 
 ---
 
-# Rule Graph Construction
+## Rule Graph Construction
 
-## Overview
+### Overview
 
 Build logic in [Pants](https://www.pantsbuild.org/) is declared using collections of `@rules` with recursively memoized and invalidated results. This framework (known as Pants' "Engine") has similar goals to Bazel's [Skyframe](https://bazel.build/designs/skyframe.html) and the [Salsa](https://github.com/salsa-rs/salsa) framework: users define logic using a particular API, and the framework manages tracking the dependencies between nodes in a runtime graph.
 
@@ -15,11 +15,11 @@ In order to maximize the amount of work that can be reused at runtime, Pants sta
 
 Concepts used in compilers, including live variable analysis and monomorphization, can also be useful in rule graph construction to minimize rule identities and pre-decide which versions of their dependencies they will use.
 
-## Concepts
+### Concepts
 
 A successfully constructed `RuleGraph` contains a graph where nodes have one of three types, `Rule`s, `Query`s, and `Param`s, which map fairly closely to what a Pants `@rule` author consumes. The edges between nodes represent dependencies: `Query`s are always roots of the graph, `Param`s are always leaves, and `Rule`s represent the end user logic making up all of the internal nodes of the graph.
 
-### Rules
+#### Rules
 
 A `Rule` is a function or coroutine with all of its inputs declared as part of its type signature. The end user type signature is made up of:
 
@@ -31,13 +31,13 @@ In the `RuleGraph`, these are encoded in a [Rule](https://github.com/pantsbuild/
 
 `Rule`s never refer to one another by name (i.e., they do not call one another by name): instead, their signature declares their requirements in terms of input/output types, and rule graph construction decides which potential dependencies will provide those requirements.
 
-### Queries
+#### Queries
 
 The roots/entrypoints of a `RuleGraph` are `Query`s, which should correspond one-to-one to external callsites that use the engine to request that values are computed. A `Query` has an output type, and a series of input types: `Query(output_type, (*input_types))`.
 
 If a user makes a request to the engine that does not have a corresponding `Query` declared, the engine fails rather than attempting to dynamically determine which `Rules` to use to answer the `Query`: how a `RuleGraph` is constructed should show why that is the case.
 
-### Params
+#### Params
 
 `Params` are typed, comparable (`eq`/`hash`) values that represent both the inputs to `Rules`, and the building block of the runtime memoization key for a `Rule`. The set of `Params` (unique by type) that are consumed to create a `Rule`'s inputs (plus the `Rule`'s own identity) make up the memoization key for a runtime instance of the `Rule`.
 
@@ -47,7 +47,7 @@ The `Param`s that are available to a `Rule` are made available by the `Rule`'s d
 
 `Params` flow down the graph from `Query`s and the provided `Param`s of `Get`s: their presence does not need to be re-declared at each intermediate callsite. When a `Rule` consumes a `Param` as a positional argument, that `Param` will no longer be available to that `Rule`'s dependencies (but it might still be present in other subgraphs adjacent to that `Rule`).
 
-## Goals
+### Goals
 
 The goals of `RuleGraph` construction are:
 
@@ -61,7 +61,7 @@ If either of the goals were removed, `RuleGraph` construction might be more stra
 
 But both of the goals are important because together they allow for an API that is easy to write `Rule`s for, with minimal boilerplate required to get the inputs needed for a `Rule` to compute a value, and minimal invalidation. Because the identity of a `Rule` is computed from its transitive input `Param`s rather than from its positional arguments, `Rule`s can accept arbitrarily-many large input values (which don't need to implement hash) with no impact on its memoization hit rate.
 
-## Constraints
+### Constraints
 
 There are a few constraints that decide which `Rule`s are able to provide dependencies for one another:
 
@@ -71,7 +71,7 @@ There are a few constraints that decide which `Rule`s are able to provide depend
 - `provided_params` - When deciding whether one `Rule` can use another `Rule` to provide the output type of a `Get`, a constraint is applied that the candidate depedency must (transitively) consume the `Param` that is provided by the `Get`.
   - For example: if a `Rule` `z` has a `Get(A, B)`, only `Rule`s that compute an `A` and (transitively) consume a `B` are eligible to be used. This also means that a `Param` `A` which is already in scope for `Rule` `z` is not eligible to be used, because it would trivially not consume `B`.
 
-## Implementation
+### Implementation
 
 As of [3a188a1e06](https://github.com/pantsbuild/pants/blob/3a188a1e06d8c27ff86d8c311ff1b2bdea0d39ff/src/rust/engine/rule_graph/src/builder.rs#L202-L219), we construct a `RuleGraph` using a combination of data flow analysis and some homegrown (and likely problematic: see the "Issue Overview") node splitting on the call graph of `Rule`s.
 

--- a/versioned_docs/version-2.15/docs/helm/index.mdx
+++ b/versioned_docs/version-2.15/docs/helm/index.mdx
@@ -11,7 +11,7 @@ Pants has good support for the most common operations for managing Helm charts s
 Please share feedback for what you need to use Pants with your Helm charts by either [opening a GitHub issue](https://github.com/pantsbuild/pants/issues/new/choose) or [joining our Slack](/community/getting-help)!
 :::
 
-# Initial setup
+## Initial setup
 
 First, activate the relevant backend in `pants.toml`:
 
@@ -40,7 +40,7 @@ name: bar
 version: 0.1.0
 ```
 
-## Adding `helm_chart` targets
+### Adding `helm_chart` targets
 
 Helm charts are identified by the presence of a `Chart.yaml` or `Chart.yml` file, which contains relevant metadata about the chart like its name, version, dependencies, etc. To get started quickly you can create a simple `Chart.yaml` file in your sources folder:
 
@@ -63,11 +63,11 @@ Created src/helm/example/BUILD:
   - Add helm_chart target example
 ```
 
-## Basic operations
+### Basic operations
 
 The given setup is enough to now do some common operations on our Helm chart source code.
 
-### Linting
+#### Linting
 
 The Helm backend has an implementation of the Pants' `lint` goal which hooks it with the `helm lint` command:
 
@@ -98,7 +98,7 @@ Likewise, in a similar way you could enable strict linting globally and then cho
 
 You can set the field `skip_lint=True` on each `helm_chart` target to avoid linting it.
 
-### Package
+#### Package
 
 Packing helm charts is supported out of the box via the Pants' `package` goal. The final package will be saved as a `.tgz` file under the `dist` folder at your source root.
 
@@ -111,7 +111,7 @@ Built Helm chart artifact: testprojects.src.helm.example/example/example-0.2.0.t
 
 The final output folder can customised using the `output_path` field in the `helm_chart` target. Run `pants help helm_chart` for more information.
 
-# Helm Unit tests
+## Helm Unit tests
 
 The Helm backend supports running Helm unit tests via the [Helm `unittest` plugin](https://github.com/quintush/helm-unittest). To run unit tests follow the instructions on how to use that plugin and then create a `BUILD` file in the same folder where your tests live with the following target:
 
@@ -159,7 +159,7 @@ pants test ::
 ✓ testprojects/src/helm/example/tests/env-configmap_test.yaml succeeded in 0.75s.
 ```
 
-### Feeding additional files to unit tests
+#### Feeding additional files to unit tests
 
 In some cases we may want our tests to have access to additional files which are not part of the chart. This can be achieved by setting a dependency between our unit test targets and a `resources` target as follows:
 
@@ -262,7 +262,7 @@ not affected by the source roots setting. When using `relocated_files`, the file
 to the value set in the `dest` field.
 :::
 
-### Timeouts
+#### Timeouts
 
 Pants can cancel tests that take too long, which is useful to prevent tests from hanging indefinitely.
 
@@ -296,13 +296,13 @@ If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will 
 
 Use the option `pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
-# Publishing Helm charts
+## Publishing Helm charts
 
 Pants only supports publishing Helm charts to OCI registries, a feature that was made generally available in Helm 3.8.
 
 The publishing is done with Pants' `publish` goal but first you will need to tell Pants what are the possible destination registries where to upload your charts.
 
-## Configuring OCI registries
+### Configuring OCI registries
 
 In a similar way as the `docker_image` target, a `helm_chart` target takes an optional `registries` field whose value is a list of registry endpoints (prefixed by the `oci://` protocol):
 
@@ -350,7 +350,7 @@ helm_chart(
 )
 ```
 
-## Setting a repository name
+### Setting a repository name
 
 When publishing charts into an OCI registry, you most likely will be interested on separating them from other kind of OCI assets (i.e. container images). For doing so you can set a `repository` field in the `helm_chart` target so the chart artifact will be uploaded to the given path:
 
@@ -370,7 +370,7 @@ You can also set a default global repository in `pants.toml` as in the following
 default_registry_repository = "charts"
 ```
 
-# Managing Chart Dependencies
+## Managing Chart Dependencies
 
 Helm charts can depend on other charts, whether first-party charts defined in the same repo, or third-party charts published in a registry. Pants uses this dependency information to know when work needs to be re-run.
 
@@ -378,7 +378,7 @@ Helm charts can depend on other charts, whether first-party charts defined in th
 To benefit from Pants dependency management and inference in your Helm charts, you will need to use `apiVersion: v2` in your `Chart.yaml` file.
 :::
 
-## `Chart.yaml` dependencies
+### `Chart.yaml` dependencies
 
 Pants will automatically infer dependencies from the `Chart.yaml` file.
 
@@ -415,7 +415,7 @@ pants dependencies src/helm/bar
 src/helm/foo
 ```
 
-## Explicitly provided dependencies in `BUILD` files
+### Explicitly provided dependencies in `BUILD` files
 
 If you prefer, you can let your BUILD files be the "source of truth" for dependencies, instead of specifying them in `Chart.yaml`:
 
@@ -443,7 +443,7 @@ helm_chart(dependencies=["//src/helm/foo"])
 
 In this case, the `pants dependencies` command will show the same result and, in addition, Pants will modify its copy of `bar`'s `Chart.yaml` before using it, so that it includes `foo` in its dependency list. Note that Pants will not modify the original copy in your source tree, only the copy it uses in the sandboxed execution environment.
 
-## Third party chart artifacts
+### Third party chart artifacts
 
 Third party charts are provided to Pants using the `helm_artifact` target:
 

--- a/versioned_docs/version-2.15/docs/introduction/welcome-to-pants.mdx
+++ b/versioned_docs/version-2.15/docs/introduction/welcome-to-pants.mdx
@@ -5,11 +5,11 @@
 
 ---
 
-# What is Pants?
+## What is Pants?
 
 Pants is a fast, scalable, user-friendly build and developer workflow system for codebases of all sizes, including yours!
 
-# What does Pants do?
+## What does Pants do?
 
 Pants installs, orchestrates and runs dozens of standard underlying tools - compilers, code generators, dependency resolvers, test runners, linters, formatters, packagers, REPLs and more - composing them into a single stable, hermetic toolchain, and speeding up your workflows via caching and concurrency.
 
@@ -17,13 +17,13 @@ Pants is designed to be easy to adopt, use, and extend. It doesn't require you t
 
 Pants is currently focused on Python, Go, Java, Scala, Shell, and Docker, with more languages and frameworks coming soon. [The Pants community](/community/members) is friendly and helpful, and supported by [Toolchain](https://toolchain.com/), a venture-backed company whose mission is to enable fast, stable, ergonomic developer workflows for everyone.
 
-# Who is Pants for?
+## Who is Pants for?
 
 Pants is useful for repos of all sizes, but is particularly valuable for those containing multiple distinct but interdependent pieces.
 
 Pants works well with (but does not require) a [_monorepo_ architecture](https://blog.pantsbuild.org/the-monorepo-approach-to-code-management/): a codebase containing multiple projects—often using multiple programming languages and frameworks—in a single unified repository. If you want to scale your codebase without breaking it up into multiple disconnected repos, with all the versioning and maintenance headaches that causes, Pants provides the tooling for you to do so effectively.
 
-# What are the main features of Pants?
+## What are the main features of Pants?
 
 Pants is designed for fast, consistent, ergonomic builds. Some noteworthy features include:
 
@@ -36,7 +36,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 - Extensibility and customizability via a plugin API
 - Code introspection features
 
-# Which languages and frameworks does Pants support?
+## Which languages and frameworks does Pants support?
 
 - Pants [ships](page:language-support) with support for [Python](../python/overview/index.mdx), [Go](../go/index.mdx), [Java](../java-and-scala/index.mdx), [Scala](../java-and-scala/index.mdx) and [Shell](../shell/index.mdx).
 - Pants supports a wide range of code generators (such as Thrift, Protobuf, Scrooge and Avro), linters and formatters, and it is easy to add support for new or custom ones
@@ -45,7 +45,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 We're listening to the community for which languages, frameworks and tools we should support next, so let us know about your needs by [opening an issue](https://github.com/pantsbuild/pants/issues/new/choose) on GitHub or [chatting with us](/community/members) about it on the community Slack!
 Pants was designed for extensibility, and we welcome [contributions](../contributions/index.mdx)!
 
-# How does Pants work?
+## How does Pants work?
 
 The core of Pants is its execution engine, which sequences and coordinates all the underlying work. The engine is written in Rust, for performance. The underlying work is performed by executing _rules_, which are typed Python 3 async coroutines for familiarity and simplicity.
 
@@ -53,17 +53,17 @@ The engine is designed so that fine-grained invalidation, concurrency, hermetici
 
 See [here](../getting-started/how-does-pants-work.mdx) for more details about the Pants engine.
 
-# Is Pants similar to X?
+## Is Pants similar to X?
 
 Pants (v2) is a leap forward in the evolution of build systems, a category that runs from the venerable Make through Ant, Maven, Gradle and SBT, to Bazel, Please, Buck, Pants v1 and others.
 
 Its design leans on ideas and inspiration from these earlier tools, while optimizing not just for speed and correctness, but also for ease of adoption, ease of use and ease of extension, all for real-world use cases at a variety of teams.
 
-# Who uses Pants?
+## Who uses Pants?
 
 Pants is making engineering teams productive and happy at a range of companies and organizations. See a sample of them [here](page:who-uses-pants)!
 
-# Who develops Pants?
+## Who develops Pants?
 
 Pants is an open-source software project, developed at [github.com/pantsbuild/pants](https://github.com/pantsbuild/pants). Pants is released under the [Apache License 2.0](https://github.com/pantsbuild/pants/blob/master/LICENSE).
 

--- a/versioned_docs/version-2.15/docs/using-pants/environments.mdx
+++ b/versioned_docs/version-2.15/docs/using-pants/environments.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Environments
+## Environments
 
 :::caution Environments are currently in `preview`, and have not yet stabilized.
 We'd love your feedback on how Environments could be most useful to you! Please refer to [the tracking issue](https://github.com/pantsbuild/pants/issues/17355) for known stabilization blockers.
@@ -17,7 +17,7 @@ By default, Pants will execute all sandboxed build work directly on localhost. B
 2. remotely via [remote execution](./remote-caching-&-execution/remote-execution.mdx)
 3. locally, but with a non-default set of environment variables and settings (such as when different platforms need different values, or when cross-building)
 
-## Defining environments
+### Defining environments
 
 Environments are defined using environment targets:
 
@@ -49,7 +49,7 @@ docker_environment(
 )
 ```
 
-### Environment-aware options
+#### Environment-aware options
 
 Environment targets have fields ([target](./key-concepts/targets-and-build-files.mdx) arguments) which correspond to [options](./key-concepts/options.mdx) which are marked "environment-aware". When an option is environment-aware, the value of the option that will be used in an environment can be overridden by setting the corresponding field value on the associated environment target. If an environment target does not set a value, it defaults to the value which is set globally via options values.
 
@@ -59,7 +59,7 @@ For example, the [`[python-bootstrap].search_path` option](../../reference/subsy
 Environments are a new concept: if you see an option value which should be marked environment-aware but isn't, please definitely [file an issue](https://github.com/pantsbuild/pants/issues/new/choose)!
 :::
 
-## Consuming environments
+### Consuming environments
 
 To declare which environment they should build with, many target types (but particularly "root" targets like tests or binaries) have an `environment=` field: for example, [`python_tests(environment=..)`](../../reference/targets/python_tests.mdx#environment).
 
@@ -74,7 +74,7 @@ Currently, there is no static validation that a target's environment is compatib
 As we gain more experience with how environments are used in the wild, it's possible that more static validation can be added: your feedback would be very welcome!
 :::
 
-### Setting the environment on many targets at once
+#### Setting the environment on many targets at once
 
 To use an environment everywhere in your repository (or only within a particular subdirectory, or with a particular target
 type), you can use the [`__defaults__` builtin](./key-concepts/targets-and-build-files.mdx#field-default-values). For example, to use an environment named `my_default_environment` globally by default, you would add the following to a `BUILD` file at the root of the repository:
@@ -85,7 +85,7 @@ __defaults__(all=dict(environment="my_default_environment"))
 
 ... and individual targets could override the default as needed.
 
-### Building one target in multiple environments
+#### Building one target in multiple environments
 
 If a target will always need to be built in multiple environments (rather than conditionally based on which user is building it: see the "Toggle use of an environment for some consumers" section), then you can use the [`parametrize` builtin](./key-concepts/targets-and-build-files.mdx#parametrizing-targets) for the `environment=` field. If you had two environments named `linux` and `macos`, that would look like:
 
@@ -96,7 +96,7 @@ pex_binary(
 )
 ```
 
-### Environment matching
+#### Environment matching
 
 A single environment name may end up referring to different environment targets on different physical machines, or with different global settings applied: this is known as environment "matching".
 
@@ -129,9 +129,9 @@ docker_environment(
 
 In future versions, environment targets will gain additional predicates to control whether they match (for example: `local_environment` will likely gain a predicate that looks for the [presence or value of an environment variable](https://github.com/pantsbuild/pants/issues/17107). But in the meantime, it's possible to override which environments are matched for particular use cases by overriding their configured names: see the "Toggle use of an environment" workflow below for an example.
 
-## Example workflows
+### Example workflows
 
-### Enabling remote execution globally
+#### Enabling remote execution globally
 
 `remote_environment` targets match unless the [`--remote-execution`](../../reference/global-options.mdx#remote_execution) option is disabled. So to cause a particular environment name to use remote execution whenever it is enabled, you could define environment targets which try remote execution first, and then fall back to local execution:
 
@@ -163,7 +163,7 @@ local = "//:local"
 The `2.15.x` series of Pants does not yet support ["speculating" remote execution](https://github.com/pantsbuild/pants/issues/8353) by racing it against another environment (usually local or docker). While we expect that this will be necessary to make remote execution a viable option for local execution on user's laptops (where network connections are less reliable), it is less critical for CI use-cases.
 :::
 
-### Use a `docker_environment` to build the inputs to a `docker_image`
+#### Use a `docker_environment` to build the inputs to a `docker_image`
 
 To build a `docker_image` target containing a `pex_binary` which uses native (i.e. compiled) dependencies on a `macOS` machine, you can configure the `pex_binary` to be built in a `docker_environment`.
 
@@ -202,7 +202,7 @@ Note that the Docker image used in your `docker_environment` does not need to ma
 This means that your `docker_environment` can include things like compilers or other tools relevant to your build, without needing to manually use multi-stage Docker builds.
 :::
 
-### Toggle use of an environment for some consumers
+#### Toggle use of an environment for some consumers
 
 As mentioned above in "Environment matching", environment targets "match" based on their field values and global options. But if two environment targets would be ambiguous in some cases, or if you'd otherwise like to control what a particular environment name means (in CI, for example), you can override an environment name via options.
 

--- a/versioned_docs/version-2.15/docs/using-pants/key-concepts/goals.mdx
+++ b/versioned_docs/version-2.15/docs/using-pants/key-concepts/goals.mdx
@@ -17,7 +17,7 @@ To see the current list of goals, run:
 
 You'll see more goals activated as you activate more [backends](./backends.mdx).
 
-# Running goals
+## Running goals
 
 For example:
 
@@ -49,7 +49,7 @@ sequentially, and then Pants will wait until a relevant file has changed to try 
 
 Use `Ctrl+C` to exit the `--loop`.
 
-# Goal arguments
+## Goal arguments
 
 Most goals require arguments to know what to work on.
 
@@ -76,7 +76,7 @@ This will become the default in Pants 2.14.
 See [Advanced target selection](../advanced-target-selection.mdx) for alternative techniques to specify which files/targets to run on.
 :::
 
-## Goal options
+### Goal options
 
 Many goals also have [options](./options.mdx) to change how they behave. Every option in Pants can be set via an environment variable, config file, and the command line.
 

--- a/versioned_docs/version-2.15/docs/using-pants/key-concepts/options.mdx
+++ b/versioned_docs/version-2.15/docs/using-pants/key-concepts/options.mdx
@@ -7,7 +7,7 @@ A deep dive into how options may be configured.
 
 ---
 
-# Option scopes
+## Option scopes
 
 Options are partitioned into named _scopes_.
 
@@ -15,7 +15,7 @@ Some systemwide options belong in the _global scope_. For example, the `--level`
 
 Other options belong to a _subsystem scope_. A _subsystem_ is simply a collection of related options, in a scope. For example, the `pytest` subsystem contains options related to [Python's test framework pytest](../../../reference/subsystems/pytest.mdx).
 
-# Setting options
+## Setting options
 
 Every option can be set in the following ways, in order of precedence:
 
@@ -27,7 +27,7 @@ If an option isn't set in one of these ways, it will take on a default value.
 
 You can inspect both the current value and the default value by using `pants help $scope` or `pants help-advanced $scope`, e.g. `pants help global`.
 
-## Command-line flags
+### Command-line flags
 
 Global options are set using an unqualified flag:
 
@@ -41,7 +41,7 @@ Subsystem options are set by providing the flag, with the name prefixed with the
 pants --source-root-patterns="['^ext']"
 ```
 
-## Environment variables
+### Environment variables
 
 Global options are set using the environment variable `PANTS_{OPTION_NAME}`:
 
@@ -58,7 +58,7 @@ PANTS_SOURCE_ROOT_PATTERNS="['^ext']" pants ...
 
 Note that the scope and option name are upper-cased, and any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `MULTIWORD_NAME`.
 
-## Config file entries
+### Config file entries
 
 Global options are set in the `GLOBAL` section of the config file:
 
@@ -76,7 +76,7 @@ root_patterns = ["/src/python"]
 
 Note that any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `multiword_name`.
 
-### Config file interpolation
+#### Config file interpolation
 
 Environment variables can be interpolated by using the syntax `%(env.ENV_VAR)s`, e.g.:
 
@@ -95,7 +95,7 @@ Additionally, a few special values are pre-populated with the `%(var)s` syntax:
 - `%(pants_distdir)s`: absolute path of the global option `--pants-distdir`, which defaults
   to `{buildroot}/dist/`
 
-# Option types
+## Option types
 
 Every option has a type, and any values you set must be of that type.
 
@@ -109,25 +109,25 @@ The option types are:
 
 A list-valued option may also declare a specific type for its members (e.g., a list of strings, or a list of integers).
 
-## String and integer values
+### String and integer values
 
 Standalone string and integer values are written without quotes. Any quotes will be considered part of the value, after shell escaping.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-intopt=42
 pants --scope-stropt=qux
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_INTOPT=42
 PANTS_SCOPE_STROPT=qux
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -135,11 +135,11 @@ intopt = 42
 stropt = "qux"
 ```
 
-## Boolean values
+### Boolean values
 
 Boolean values can be specified using the special strings `true` and `false`. When specifying them via command-line flags you can also use the `--boolopt/--no-boolopt` syntax.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-boolopt=true
@@ -147,24 +147,24 @@ pants --scope-boolopt
 pants --no-scope-boolopt
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_BOOLOPT=true
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
 boolopt = true
 ```
 
-## List values
+### List values
 
 List values are parsed as Python list literals, so you must quote string values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-listopt="['foo','bar']"
@@ -178,7 +178,7 @@ pants --scope-listopt=foo --scope-listopt=bar
 
 Appending will add to any values from lower-precedence sources, such as config files (`pants.toml`) and possibly Pants's `default`. Otherwise, using `[]` will override any lower-precedence sources.
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_LISTOPT="['foo','bar']"
@@ -190,7 +190,7 @@ Like with command-line flags, you can leave off the `[]` to _append_ elements:
 PANTS_SCOPE_LISTOPT=foo
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -200,7 +200,7 @@ listopt = [
 ]
 ```
 
-### Add/remove semantics
+#### Add/remove semantics
 
 List values have some extra semantics:
 
@@ -250,23 +250,23 @@ listopt.remove = [3, 4]
 But note that this only works in Pants's `.toml` config files, not in environment variables or command-line flags.
 :::
 
-## Dict values
+### Dict values
 
 Dict values are parsed as Python dict literals on the command-line and environment variables, so you must quote string keys and values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-dictopt="{'foo':1,'bar':2}"
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_DICTOPT="{'foo':1,'bar':2}"
 ```
 
-### Config file entries:
+#### Config file entries:
 
 You can use TOML's [nested table features](https://toml.io/en/v1.0.0#inline-table). These are equivalent:
 
@@ -291,7 +291,7 @@ dictopt = """{
 }"""
 ```
 
-### Add/replace semantics
+#### Add/replace semantics
 
 - A value can be preceded by `+`, which will _update_ the value obtained from lower-precedence sources with the entries.
 - Otherwise, the value _replaces_ the one obtained from lower-precendence sources.
@@ -310,7 +310,7 @@ pants --scope-dictopt="{'foo':42,'baz':3}"
 
 will set the value to `{'foo': 42, 'baz': 3}`.
 
-# Reading individual option values from files
+## Reading individual option values from files
 
 If an option value is too large or elaborate to use directly, or if you don't want to hard-code
 values directly in `pants.toml`, you can set the value of any option to the string
@@ -345,7 +345,7 @@ do so by `kill`ing it (after using `ps -ef | grep pantsd` to find its pid), or b
 Pants once with `--no-pantsd`.
 :::
 
-# `.pants.rc` file
+## `.pants.rc` file
 
 You can set up personal Pants config files, using the same TOML syntax as `pants.toml`. By default, Pants looks for the paths `/etc/pantsrc`, `~/.pants.rc`, and `.pants.rc` in the repository root.
 

--- a/versioned_docs/version-2.15/docs/using-pants/key-concepts/source-roots.mdx
+++ b/versioned_docs/version-2.15/docs/using-pants/key-concepts/source-roots.mdx
@@ -13,7 +13,7 @@ Go does have a notion of source roots: where your `go.mod` is located. However, 
 Shell does not have any notion of source roots.
 :::
 
-# What are source roots?
+## What are source roots?
 
 Some project layouts use top-level folders for namespace purposes, but have the code live underneath. However, the code's imports will ignore these top-level folders, thanks to mechanisms like the `$PYTHONPATH` and the JVM classpath. _Source roots_ are a generic equivalent of these concepts.
 
@@ -44,7 +44,7 @@ pkgutil.get_data("project.config", "prod.json")
 
 In the example above, `src/python` is a source root. So, when some code says `from project.app import App`, Pants can know that this corresponds to the code in `src/python/project/app.py`.
 
-# Configuring source roots
+## Configuring source roots
 
 There are two ways to configure source roots:
 
@@ -60,7 +60,7 @@ src/python
 src/rust
 ```
 
-## Configuring source roots using patterns
+### Configuring source roots using patterns
 
 You can provide a set of patterns that match your source roots:
 
@@ -85,7 +85,7 @@ You can use `*` as a glob. For example, `root_patterns = ["/src/*"]` would consi
 - `src/java`
 - `src/assets`
 
-### Configuring no source roots
+#### Configuring no source roots
 
 Many projects do not have any top-level folders used for namespacing.
 
@@ -125,7 +125,7 @@ The default value of the `root_patterns` config key is `["/", "src", "src/python
 These capture a range of common cases, including a source root at the root of the repository. If your source roots match these patterns, you don't need to explicitly configure them.
 :::
 
-## Configuring source roots using marker files
+### Configuring source roots using marker files
 
 You can also denote your source roots using specially-named marker files. To do so, first pick a name (or multiple names) to use:
 
@@ -182,15 +182,15 @@ import server.server.app
 from utils.utils.strutil import capitalize
 ```
 
-# Examples
+## Examples
 
 These project structures are all valid; Pants does not expect you to reorganize your codebase to use the tool.
 
-## `src/<lang>` setup
+### `src/<lang>` setup
 
 This setup is common in "polyglot" repositories: i.e. repos with multiple languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -228,7 +228,7 @@ This setup is common in "polyglot" repositories: i.e. repos with multiple langua
 
 While we have tests in a separate source root here, it's also valid to have tests colocated with their src files.
 
-### Example imports:
+#### Example imports:
 
 ```python
 # Python
@@ -242,7 +242,7 @@ import org.pantsbuild.project.App
 import org.pantsbuild.project.util.Math
 ```
 
-### Config:
+#### Config:
 
 ```toml title="pants.toml"
 [source]
@@ -255,9 +255,9 @@ root_patterns = [
 
 Note that we organized our 3rdparty requirements in the top-level folders `3rdparty/python` and `3rdparty/java`, but we do not need to include them as source roots because we do not have any first-party code there.
 
-## Multiple top-level projects
+### Multiple top-level projects
 
-### Project:
+#### Project:
 
 This layout has lots of nesting; this is only one possible way to organize the repository.
 
@@ -289,7 +289,7 @@ This layout has lots of nesting; this is only one possible way to organize the r
         └── spa.js
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 import ads.billing.calculate_bill
@@ -299,7 +299,7 @@ from base.util.math import add_two
 
 Note that even though the projects live in different top-level folders, you are still able to import from other projects. If you would like to limit this, you can use `pants dependees` or `pants dependencies` in CI to track where imports are being used. See [Project introspection](../project-introspection.mdx).
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 
@@ -320,11 +320,11 @@ root_patterns = [
 ]
 ```
 
-## No source root
+### No source root
 
 Warning: while this project structure is valid, it often does not scale as well as your codebase grows, such as adding new languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -340,7 +340,7 @@ Warning: while this project structure is valid, it often does not scale as well 
 └── pyproject.toml
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 from project.app import App
@@ -349,7 +349,7 @@ from project.util.math import add_two
 pkgutil.get_data("project.config", "prod.json")
 ```
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 

--- a/versioned_docs/version-2.15/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/versioned_docs/version-2.15/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -23,7 +23,7 @@ To reduce boilerplate, some targets also generate other targets:
 - `shell_sources` -> `shell_source`
 - `go_mod` -> `go_third_party_package`
 
-# BUILD files
+## BUILD files
 
 Targets are defined in files with the name `BUILD`. For example:
 
@@ -45,7 +45,7 @@ All target types have a `name` field, which is used to identify the target. Targ
 
 You can autoformat `BUILD` files by enabling a `BUILD` file formatter by adding it to `[GLOBAL].backend_packages` in `pants.toml` (such as `pants.backend.build_files.fmt.black` [or others](./backends.mdx)). Then to format, run `pants fmt '**/BUILD'` or `pants fmt ::` (formats everything).
 
-# Target addresses
+## Target addresses
 
 A target is identified by its unique address, in the form `path/to/dir:name`. The above example has the addresses `helloworld/greet:tests` and `helloworld/greet:bin`.
 
@@ -68,7 +68,7 @@ You can refer to this target with either `helloworld/greet:greet` or the abbrevi
 Addressed defined in the `BUILD` file at the root of your repository are prefixed with `//`, e.g. `//:my_tgt`.
 :::
 
-# `source` and `sources` field
+## `source` and `sources` field
 
 Targets like `python_test` and `resource` have a `source: str` field, while target generators like `python_tests` and `resources` have a `sources: list[str]` field. This determines which source files belong to the target.
 
@@ -108,7 +108,7 @@ Including the same file in the `source` / `sources` field for multiple targets c
 You can run `pants list path/to/file.ext` to see all "owning" targets to check if >1 target has the file in its `source` field.
 :::
 
-# `dependencies` field
+## `dependencies` field
 
 A target's dependencies determines which other first-party code and third-party requirements to include when building the target.
 
@@ -151,7 +151,7 @@ You can use the prefix `!!` to transitively exclude a dependency, meaning that e
 Transitive excludes can only be used in target types that conventionally are not dependend upon by other targets, such as `pex_binary` and `python_test` / `python_tests`. This is meant to limit confusion, as using `!!` in something like a `python_source` / `python_sources` target could result in surprising behavior for everything that depends on it. (Pants will print a helpful error when using `!!` when it's not legal.)
 :::
 
-# Field default values
+## Field default values
 
 As mentioned above in [BUILD files](./targets-and-build-files.mdx#build-files), most target fields have sensible defaults. And it's easy to override those values on a specific target. But applying the same non-default value on many targets can get unwieldy, error-prone and hard to maintain. Enter `__defaults__`.
 
@@ -196,7 +196,7 @@ To reset any modified defaults, simply override with the empty dict:
     __defaults__(all={})
 ```
 
-## Supporting optional plugin fields
+### Supporting optional plugin fields
 
 Normally Pants presents an error message when attempting to provide a default value for a field that doesn't exist for the target. However, some fields comes from plugins, and to support disabling a plugin without having to remove any default values referencing any plugin fields it was providing, there is a `ignore_unknown_fields` option to use:
 
@@ -209,7 +209,7 @@ Normally Pants presents an error message when attempting to provide a default va
     )
 ```
 
-# Target generation
+## Target generation
 
 To reduce boilerplate, Pants provides target types that generate other targets. For example:
 
@@ -287,7 +287,7 @@ It's useful for metadata to be as fine-grained as feasible, such as by using the
 [`pants tailor ::`](../../getting-started/initial-configuration.mdx#5-generate-build-files) will automatically create targets that only apply metadata for the directory.
 :::
 
-# Parametrizing targets
+## Parametrizing targets
 
 It can be useful to create multiple targets describing the same entity, each with different metadata. For example:
 

--- a/versioned_docs/version-2.15/docs/using-pants/remote-caching-&-execution/index.mdx
+++ b/versioned_docs/version-2.15/docs/using-pants/remote-caching-&-execution/index.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Overview
+## Overview
 
 By default, Pants executes processes in a local [environment](../environments.mdx) on the system on which it is run, and caches the results of those processes locally as well. Besides this "local execution" mode of operation, Pants also supports two distributed modes of operation:
 
@@ -15,7 +15,7 @@ By default, Pants executes processes in a local [environment](../environments.md
 
 Pants does this by using the "Remote Execution API" to converse with the remote cache or remote execution server.
 
-## What is Remote Execution API?
+### What is Remote Execution API?
 
 Pants is compatible with remote caching and remote execution servers that comply with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI protocol is supported by several different server and client projects including Bazel and of course Pants.
 
@@ -31,7 +31,7 @@ Pants calls the CAS a "store server" and the execution service an "execution ser
 
 The REAPI model contains the notion of an "instance." An "instance" is a distinct deployment of a CAS and/or execution service that is given a specific name. All REAPI operations send an instance name to the server, thus a single network endpoint can conceivably support multiple REAPI deployments.
 
-# Server compatibility
+## Server compatibility
 
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
@@ -54,6 +54,6 @@ Bazel Remote Cache supports local disk, S3, GCS, and Azure Blob storage options 
 There are a few [other](https://github.com/bazelbuild/remote-apis) systems and services in this space, but
 they have not, to our knowledge, been tested with Pants. Let us know if you have any experience with them!
 
-# Resources
+## Resources
 
 - The [remote-apis-testing project](https://gitlab.com/remote-apis-testing/remote-apis-testing) maintains a compatibility test suite of the various server and client implementations of REAPI.

--- a/versioned_docs/version-2.15/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
+++ b/versioned_docs/version-2.15/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
@@ -5,17 +5,17 @@
 
 ---
 
-# What is remote caching?
+## What is remote caching?
 
 Remote caching allows Pants to store and retrieve the results of process execution to and from a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"), rather than only using your machine's local Pants cache. This allows Pants to share a cache across different runs and different machines, for example, all of your CI workers sharing the same fine-grained cache.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote caching requires the availability of a REAPI-compatible cache. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants Configuration
+### Pants Configuration
 
 After you have either set up a REAPI cache server or obtained access to one, the next step is to point Pants to it so that Pants will use it to read and write process results.
 
@@ -31,6 +31,6 @@ remote_instance_name = "main"
 
 If the endpoint is using TLS, then the `remote_store_address` option would be specified with the `grpcs://` scheme, i.e. `"grpcs://cache.corp.example.com:8980"`.
 
-# Reference
+## Reference
 
 Run `pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.

--- a/versioned_docs/version-2.15/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
+++ b/versioned_docs/version-2.15/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
@@ -9,17 +9,17 @@
 Remote execution support in Pants comes with several limitations. For example, Pants requires that the server's operating system match the client's operating system. In practice, this means that Pants must be running on Linux because all three major server projects generally only operate on Linux.
 :::
 
-# What is remote execution?
+## What is remote execution?
 
 "Remote execution" allows Pants to offload execution of processes to a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI standard is supported by several different server and client projects including Bazel and of course Pants.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote execution requires the availability of a REAPI-compatible execution server. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants
+### Pants
 
 After you have either set up a REAPI server or obtained access to one, the next step is to point Pants to it so that Pants may submit REAPI execution requests. The server should be running a CAS and execution service. These may be the same network endpoint, but for Pants' purposes, they are configured by different configuration options.
 
@@ -33,7 +33,7 @@ remote_execution_address = "grpc://build.corp.example.com:8980"
 remote_instance_name = "main"
 ```
 
-### Environment-specific settings
+#### Environment-specific settings
 
 The REAPI execution service selects a worker for a process by consulting the "platform properties" that are passed in a remote execution request. These platform properties are key/value pairs that are configured for particular workers in the server. Generally, you will configure these in the server (or be provided them by your server's administrator), and then configure Pants to match particular workers using their relevant platform properties.
 
@@ -52,7 +52,7 @@ remote_environment(
 
 Your `remote_environment` will also need to override any [environment-aware options](../environments.mdx) which configure the relevant tools used in your repository. For example: if building Python code, a Python interpreter must be available and matched via the environment-aware options of `[python-bootstrap]`. If using protobuf support, then you may also need `unzip` available in the remote execution environment in order to unpack the protoc archive. Etc.
 
-### Concurrency
+#### Concurrency
 
 Finally, you should configure Pants to limit the number of concurrent execution requests that are sent to the REAPI server. The `process_execution_remote_parallelism` option controls this concurrency. For example, if `process_execution_remote_parallelism` is set to `20`, then Pants will only send a maximum of 20 execution requests at a single moment of time.
 
@@ -72,7 +72,7 @@ remote_execution_extra_platform_properties = [
 process_execution_remote_parallelism = 20
 ```
 
-### TLS
+#### TLS
 
 You can enable TLS by prefixing the `remote_store_address` and `remote_execution_address` with `grpcs://` instead of `grpc://`.
 
@@ -90,7 +90,7 @@ remote_instance_name = "main"
 remote_ca_certs_path = "/etc/ssl/certs/ca-certificates.crt"
 ```
 
-# Reference
+## Reference
 
 For global options, run `pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.
 

--- a/versioned_docs/version-2.16/docs/contributions/development/internal-architecture.mdx
+++ b/versioned_docs/version-2.16/docs/contributions/development/internal-architecture.mdx
@@ -5,9 +5,9 @@
 
 ---
 
-# Rule Graph Construction
+## Rule Graph Construction
 
-## Overview
+### Overview
 
 Build logic in [Pants](https://www.pantsbuild.org/) is declared using collections of `@rules` with recursively memoized and invalidated results. This framework (known as Pants' "Engine") has similar goals to Bazel's [Skyframe](https://bazel.build/designs/skyframe.html) and the [Salsa](https://github.com/salsa-rs/salsa) framework: users define logic using a particular API, and the framework manages tracking the dependencies between nodes in a runtime graph.
 
@@ -15,11 +15,11 @@ In order to maximize the amount of work that can be reused at runtime, Pants sta
 
 Concepts used in compilers, including live variable analysis and monomorphization, can also be useful in rule graph construction to minimize rule identities and pre-decide which versions of their dependencies they will use.
 
-## Concepts
+### Concepts
 
 A successfully constructed `RuleGraph` contains a graph where nodes have one of three types, `Rule`s, `Query`s, and `Param`s, which map fairly closely to what a Pants `@rule` author consumes. The edges between nodes represent dependencies: `Query`s are always roots of the graph, `Param`s are always leaves, and `Rule`s represent the end user logic making up all of the internal nodes of the graph.
 
-### Rules
+#### Rules
 
 A `Rule` is a function or coroutine with all of its inputs declared as part of its type signature. The end user type signature is made up of:
 
@@ -31,13 +31,13 @@ In the `RuleGraph`, these are encoded in a [Rule](https://github.com/pantsbuild/
 
 `Rule`s never refer to one another by name (i.e., they do not call one another by name): instead, their signature declares their requirements in terms of input/output types, and rule graph construction decides which potential dependencies will provide those requirements.
 
-### Queries
+#### Queries
 
 The roots/entrypoints of a `RuleGraph` are `Query`s, which should correspond one-to-one to external callsites that use the engine to request that values are computed. A `Query` has an output type, and a series of input types: `Query(output_type, (*input_types))`.
 
 If a user makes a request to the engine that does not have a corresponding `Query` declared, the engine fails rather than attempting to dynamically determine which `Rules` to use to answer the `Query`: how a `RuleGraph` is constructed should show why that is the case.
 
-### Params
+#### Params
 
 `Params` are typed, comparable (`eq`/`hash`) values that represent both the inputs to `Rules`, and the building block of the runtime memoization key for a `Rule`. The set of `Params` (unique by type) that are consumed to create a `Rule`'s inputs (plus the `Rule`'s own identity) make up the memoization key for a runtime instance of the `Rule`.
 
@@ -47,7 +47,7 @@ The `Param`s that are available to a `Rule` are made available by the `Rule`'s d
 
 `Params` flow down the graph from `Query`s and the provided `Param`s of `Get`s: their presence does not need to be re-declared at each intermediate callsite. When a `Rule` consumes a `Param` as a positional argument, that `Param` will no longer be available to that `Rule`'s dependencies (but it might still be present in other subgraphs adjacent to that `Rule`).
 
-## Goals
+### Goals
 
 The goals of `RuleGraph` construction are:
 
@@ -61,7 +61,7 @@ If either of the goals were removed, `RuleGraph` construction might be more stra
 
 But both of the goals are important because together they allow for an API that is easy to write `Rule`s for, with minimal boilerplate required to get the inputs needed for a `Rule` to compute a value, and minimal invalidation. Because the identity of a `Rule` is computed from its transitive input `Param`s rather than from its positional arguments, `Rule`s can accept arbitrarily-many large input values (which don't need to implement hash) with no impact on its memoization hit rate.
 
-## Constraints
+### Constraints
 
 There are a few constraints that decide which `Rule`s are able to provide dependencies for one another:
 
@@ -71,7 +71,7 @@ There are a few constraints that decide which `Rule`s are able to provide depend
 - `provided_params` - When deciding whether one `Rule` can use another `Rule` to provide the output type of a `Get`, a constraint is applied that the candidate depedency must (transitively) consume the `Param` that is provided by the `Get`.
   - For example: if a `Rule` `z` has a `Get(A, B)`, only `Rule`s that compute an `A` and (transitively) consume a `B` are eligible to be used. This also means that a `Param` `A` which is already in scope for `Rule` `z` is not eligible to be used, because it would trivially not consume `B`.
 
-## Implementation
+### Implementation
 
 As of [3a188a1e06](https://github.com/pantsbuild/pants/blob/3a188a1e06d8c27ff86d8c311ff1b2bdea0d39ff/src/rust/engine/rule_graph/src/builder.rs#L202-L219), we construct a `RuleGraph` using a combination of data flow analysis and some homegrown (and likely problematic: see the "Issue Overview") node splitting on the call graph of `Rule`s.
 

--- a/versioned_docs/version-2.16/docs/helm/index.mdx
+++ b/versioned_docs/version-2.16/docs/helm/index.mdx
@@ -11,7 +11,7 @@ Pants has good support for the most common operations for managing Helm charts s
 Please share feedback for what you need to use Pants with your Helm charts by either [opening a GitHub issue](https://github.com/pantsbuild/pants/issues/new/choose) or [joining our Slack](/community/getting-help)!
 :::
 
-# Initial setup
+## Initial setup
 
 First, activate the relevant backend in `pants.toml`:
 
@@ -40,7 +40,7 @@ name: bar
 version: 0.1.0
 ```
 
-## Adding `helm_chart` targets
+### Adding `helm_chart` targets
 
 Helm charts are identified by the presence of a `Chart.yaml` or `Chart.yml` file, which contains relevant metadata about the chart like its name, version, dependencies, etc. To get started quickly you can create a simple `Chart.yaml` file in your sources folder:
 
@@ -63,11 +63,11 @@ Created src/helm/example/BUILD:
   - Add helm_chart target example
 ```
 
-## Basic operations
+### Basic operations
 
 The given setup is enough to now do some common operations on our Helm chart source code.
 
-### Linting
+#### Linting
 
 The Helm backend has an implementation of the Pants' `lint` goal which hooks it with the `helm lint` command:
 
@@ -98,7 +98,7 @@ Likewise, in a similar way you could enable strict linting globally and then cho
 
 You can set the field `skip_lint=True` on each `helm_chart` target to avoid linting it.
 
-### Package
+#### Package
 
 Packing helm charts is supported out of the box via the Pants' `package` goal. The final package will be saved as a `.tgz` file under the `dist` folder at your source root.
 
@@ -111,7 +111,7 @@ Built Helm chart artifact: testprojects.src.helm.example/example/example-0.2.0.t
 
 The final output folder can customised using the `output_path` field in the `helm_chart` target. Run `pants help helm_chart` for more information.
 
-# Helm Unit tests
+## Helm Unit tests
 
 The Helm backend supports running Helm unit tests via the [Helm `unittest` plugin](https://github.com/quintush/helm-unittest). To run unit tests follow the instructions on how to use that plugin and then create a `BUILD` file in the same folder where your tests live with the following target:
 
@@ -159,7 +159,7 @@ pants test ::
 ✓ testprojects/src/helm/example/tests/env-configmap_test.yaml succeeded in 0.75s.
 ```
 
-### Feeding additional files to unit tests
+#### Feeding additional files to unit tests
 
 In some cases we may want our tests to have access to additional files which are not part of the chart. This can be achieved by setting a dependency between our unit test targets and a `resources` target as follows:
 
@@ -262,7 +262,7 @@ not affected by the source roots setting. When using `relocated_files`, the file
 to the value set in the `dest` field.
 :::
 
-### Timeouts
+#### Timeouts
 
 Pants can cancel tests that take too long, which is useful to prevent tests from hanging indefinitely.
 
@@ -296,13 +296,13 @@ If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will 
 
 Use the option `pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
-# Publishing Helm charts
+## Publishing Helm charts
 
 Pants only supports publishing Helm charts to OCI registries, a feature that was made generally available in Helm 3.8.
 
 The publishing is done with Pants' `publish` goal but first you will need to tell Pants what are the possible destination registries where to upload your charts.
 
-## Configuring OCI registries
+### Configuring OCI registries
 
 In a similar way as the `docker_image` target, a `helm_chart` target takes an optional `registries` field whose value is a list of registry endpoints (prefixed by the `oci://` protocol):
 
@@ -350,7 +350,7 @@ helm_chart(
 )
 ```
 
-## Setting a repository name
+### Setting a repository name
 
 When publishing charts into an OCI registry, you most likely will be interested on separating them from other kind of OCI assets (i.e. container images). For doing so you can set a `repository` field in the `helm_chart` target so the chart artifact will be uploaded to the given path:
 
@@ -370,7 +370,7 @@ You can also set a default global repository in `pants.toml` as in the following
 default_registry_repository = "charts"
 ```
 
-# Managing Chart Dependencies
+## Managing Chart Dependencies
 
 Helm charts can depend on other charts, whether first-party charts defined in the same repo, or third-party charts published in a registry. Pants uses this dependency information to know when work needs to be re-run.
 
@@ -378,7 +378,7 @@ Helm charts can depend on other charts, whether first-party charts defined in th
 To benefit from Pants dependency management and inference in your Helm charts, you will need to use `apiVersion: v2` in your `Chart.yaml` file.
 :::
 
-## `Chart.yaml` dependencies
+### `Chart.yaml` dependencies
 
 Pants will automatically infer dependencies from the `Chart.yaml` file.
 
@@ -415,7 +415,7 @@ pants dependencies src/helm/bar
 src/helm/foo
 ```
 
-## Explicitly provided dependencies in `BUILD` files
+### Explicitly provided dependencies in `BUILD` files
 
 If you prefer, you can let your BUILD files be the "source of truth" for dependencies, instead of specifying them in `Chart.yaml`:
 
@@ -443,7 +443,7 @@ helm_chart(dependencies=["//src/helm/foo"])
 
 In this case, the `pants dependencies` command will show the same result and, in addition, Pants will modify its copy of `bar`'s `Chart.yaml` before using it, so that it includes `foo` in its dependency list. Note that Pants will not modify the original copy in your source tree, only the copy it uses in the sandboxed execution environment.
 
-## Third party chart artifacts
+### Third party chart artifacts
 
 Third party charts are provided to Pants using the `helm_artifact` target:
 

--- a/versioned_docs/version-2.16/docs/introduction/welcome-to-pants.mdx
+++ b/versioned_docs/version-2.16/docs/introduction/welcome-to-pants.mdx
@@ -5,11 +5,11 @@
 
 ---
 
-# What is Pants?
+## What is Pants?
 
 Pants is a fast, scalable, user-friendly build and developer workflow system for codebases of all sizes, including yours!
 
-# What does Pants do?
+## What does Pants do?
 
 Pants installs, orchestrates and runs dozens of standard underlying tools - compilers, code generators, dependency resolvers, test runners, linters, formatters, packagers, REPLs and more - composing them into a single stable, hermetic toolchain, and speeding up your workflows via caching and concurrency.
 
@@ -17,13 +17,13 @@ Pants is designed to be easy to adopt, use, and extend. It doesn't require you t
 
 Pants is currently focused on Python, Go, Java, Scala, Shell, and Docker, with more languages and frameworks coming soon. [The Pants community](/community/members) is friendly and helpful, and supported by [Toolchain](https://toolchain.com/), a venture-backed company whose mission is to enable fast, stable, ergonomic developer workflows for everyone.
 
-# Who is Pants for?
+## Who is Pants for?
 
 Pants is useful for repos of all sizes, but is particularly valuable for those containing multiple distinct but interdependent pieces.
 
 Pants works well with (but does not require) a [_monorepo_ architecture](https://blog.pantsbuild.org/the-monorepo-approach-to-code-management/): a codebase containing multiple projects—often using multiple programming languages and frameworks—in a single unified repository. If you want to scale your codebase without breaking it up into multiple disconnected repos, with all the versioning and maintenance headaches that causes, Pants provides the tooling for you to do so effectively.
 
-# What are the main features of Pants?
+## What are the main features of Pants?
 
 Pants is designed for fast, consistent, ergonomic builds. Some noteworthy features include:
 
@@ -36,7 +36,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 - Extensibility and customizability via a plugin API
 - Code introspection features
 
-# Which languages and frameworks does Pants support?
+## Which languages and frameworks does Pants support?
 
 - Pants [ships](page:language-support) with support for [Python](../python/overview/index.mdx), [Go](../go/index.mdx), [Java](../java-and-scala/index.mdx), [Scala](../java-and-scala/index.mdx) and [Shell](../shell/index.mdx).
 - Pants supports a wide range of code generators (such as Thrift, Protobuf, Scrooge and Avro), linters and formatters, and it is easy to add support for new or custom ones
@@ -45,7 +45,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 We're listening to the community for which languages, frameworks and tools we should support next, so let us know about your needs by [opening an issue](https://github.com/pantsbuild/pants/issues/new/choose) on GitHub or [chatting with us](/community/members) about it on the community Slack!
 Pants was designed for extensibility, and we welcome [contributions](../contributions/index.mdx)!
 
-# How does Pants work?
+## How does Pants work?
 
 The core of Pants is its execution engine, which sequences and coordinates all the underlying work. The engine is written in Rust, for performance. The underlying work is performed by executing _rules_, which are typed Python 3 async coroutines for familiarity and simplicity.
 
@@ -53,17 +53,17 @@ The engine is designed so that fine-grained invalidation, concurrency, hermetici
 
 See [here](./how-does-pants-work.mdx) for more details about the Pants engine.
 
-# Is Pants similar to X?
+## Is Pants similar to X?
 
 Pants (v2) is a leap forward in the evolution of build systems, a category that runs from the venerable Make through Ant, Maven, Gradle and SBT, to Bazel, Please, Buck, Pants v1 and others.
 
 Its design leans on ideas and inspiration from these earlier tools, while optimizing not just for speed and correctness, but also for ease of adoption, ease of use and ease of extension, all for real-world use cases at a variety of teams.
 
-# Who uses Pants?
+## Who uses Pants?
 
 Pants is making engineering teams productive and happy at a range of companies and organizations. See a sample of them [here](page:who-uses-pants)!
 
-# Who develops Pants?
+## Who develops Pants?
 
 Pants is an open-source software project, developed at [github.com/pantsbuild/pants](https://github.com/pantsbuild/pants). Pants is released under the [Apache License 2.0](https://github.com/pantsbuild/pants/blob/master/LICENSE).
 

--- a/versioned_docs/version-2.16/docs/using-pants/environments.mdx
+++ b/versioned_docs/version-2.16/docs/using-pants/environments.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Environments
+## Environments
 
 :::caution Environments are currently in `preview`, and have not yet stabilized.
 We'd love your feedback on how Environments could be most useful to you! Please refer to [the tracking issue](https://github.com/pantsbuild/pants/issues/17355) for known stabilization blockers.
@@ -17,7 +17,7 @@ By default, Pants will execute all sandboxed build work directly on localhost. B
 2. remotely via [remote execution](./remote-caching-&-execution/remote-execution.mdx)
 3. locally, but with a non-default set of environment variables and settings (such as when different platforms need different values, or when cross-building)
 
-## Defining environments
+### Defining environments
 
 Environments are defined using environment targets:
 
@@ -49,7 +49,7 @@ docker_environment(
 )
 ```
 
-### Environment-aware options
+#### Environment-aware options
 
 Environment targets have fields ([target](./key-concepts/targets-and-build-files.mdx) arguments) which correspond to [options](./key-concepts/options.mdx) which are marked "environment-aware". When an option is environment-aware, the value of the option that will be used in an environment can be overridden by setting the corresponding field value on the associated environment target. If an environment target does not set a value, it defaults to the value which is set globally via options values.
 
@@ -59,7 +59,7 @@ For example, the [`[python-bootstrap].search_path` option](../../reference/subsy
 Environments are a new concept: if you see an option value which should be marked environment-aware but isn't, please definitely [file an issue](https://github.com/pantsbuild/pants/issues/new/choose)!
 :::
 
-## Consuming environments
+### Consuming environments
 
 To declare which environment they should build with, many target types (but particularly "root" targets like tests or binaries) have an `environment=` field: for example, [`python_tests(environment=..)`](../../reference/targets/python_tests.mdx#environment).
 
@@ -74,7 +74,7 @@ Currently, there is no static validation that a target's environment is compatib
 As we gain more experience with how environments are used in the wild, it's possible that more static validation can be added: your feedback would be very welcome!
 :::
 
-### Setting the environment on many targets at once
+#### Setting the environment on many targets at once
 
 To use an environment everywhere in your repository (or only within a particular subdirectory, or with a particular target
 type), you can use the [`__defaults__` builtin](./key-concepts/targets-and-build-files.mdx#field-default-values). For example, to use an environment named `my_default_environment` globally by default, you would add the following to a `BUILD` file at the root of the repository:
@@ -85,7 +85,7 @@ __defaults__(all=dict(environment="my_default_environment"))
 
 ... and individual targets could override the default as needed.
 
-### Building one target in multiple environments
+#### Building one target in multiple environments
 
 If a target will always need to be built in multiple environments (rather than conditionally based on which user is building it: see the "Toggle use of an environment for some consumers" section), then you can use the [`parametrize` builtin](./key-concepts/targets-and-build-files.mdx#parametrizing-targets) for the `environment=` field. If you had two environments named `linux` and `macos`, that would look like:
 
@@ -96,7 +96,7 @@ pex_binary(
 )
 ```
 
-### Environment matching
+#### Environment matching
 
 A single environment name may end up referring to different environment targets on different physical machines, or with different global settings applied: this is known as environment "matching".
 
@@ -129,9 +129,9 @@ docker_environment(
 
 In future versions, environment targets will gain additional predicates to control whether they match (for example: `local_environment` will likely gain a predicate that looks for the [presence or value of an environment variable](https://github.com/pantsbuild/pants/issues/17107). But in the meantime, it's possible to override which environments are matched for particular use cases by overriding their configured names: see the "Toggle use of an environment" workflow below for an example.
 
-## Example workflows
+### Example workflows
 
-### Enabling remote execution globally
+#### Enabling remote execution globally
 
 `remote_environment` targets match unless the [`--remote-execution`](../../reference/global-options.mdx#remote_execution) option is disabled. So to cause a particular environment name to use remote execution whenever it is enabled, you could define environment targets which try remote execution first, and then fall back to local execution:
 
@@ -163,7 +163,7 @@ local = "//:local"
 The `2.15.x` series of Pants does not yet support ["speculating" remote execution](https://github.com/pantsbuild/pants/issues/8353) by racing it against another environment (usually local or docker). While we expect that this will be necessary to make remote execution a viable option for local execution on user's laptops (where network connections are less reliable), it is less critical for CI use-cases.
 :::
 
-### Use a `docker_environment` to build the inputs to a `docker_image`
+#### Use a `docker_environment` to build the inputs to a `docker_image`
 
 To build a `docker_image` target containing a `pex_binary` which uses native (i.e. compiled) dependencies on a `macOS` machine, you can configure the `pex_binary` to be built in a `docker_environment`.
 
@@ -202,7 +202,7 @@ Note that the Docker image used in your `docker_environment` does not need to ma
 This means that your `docker_environment` can include things like compilers or other tools relevant to your build, without needing to manually use multi-stage Docker builds.
 :::
 
-### Toggle use of an environment for some consumers
+#### Toggle use of an environment for some consumers
 
 As mentioned above in "Environment matching", environment targets "match" based on their field values and global options. But if two environment targets would be ambiguous in some cases, or if you'd otherwise like to control what a particular environment name means (in CI, for example), you can override an environment name via options.
 

--- a/versioned_docs/version-2.16/docs/using-pants/key-concepts/goals.mdx
+++ b/versioned_docs/version-2.16/docs/using-pants/key-concepts/goals.mdx
@@ -17,7 +17,7 @@ To see the current list of goals, run:
 
 You'll see more goals activated as you activate more [backends](./backends.mdx).
 
-# Running goals
+## Running goals
 
 For example:
 
@@ -49,7 +49,7 @@ sequentially, and then Pants will wait until a relevant file has changed to try 
 
 Use `Ctrl+C` to exit the `--loop`.
 
-# Goal arguments
+## Goal arguments
 
 Most goals require arguments to know what to work on.
 
@@ -76,7 +76,7 @@ This will become the default in Pants 2.14.
 See [Advanced target selection](../advanced-target-selection.mdx) for alternative techniques to specify which files/targets to run on.
 :::
 
-## Goal options
+### Goal options
 
 Many goals also have [options](./options.mdx) to change how they behave. Every option in Pants can be set via an environment variable, config file, and the command line.
 

--- a/versioned_docs/version-2.16/docs/using-pants/key-concepts/options.mdx
+++ b/versioned_docs/version-2.16/docs/using-pants/key-concepts/options.mdx
@@ -7,7 +7,7 @@ A deep dive into how options may be configured.
 
 ---
 
-# Option scopes
+## Option scopes
 
 Options are partitioned into named _scopes_.
 
@@ -15,7 +15,7 @@ Some systemwide options belong in the _global scope_. For example, the `--level`
 
 Other options belong to a _subsystem scope_. A _subsystem_ is simply a collection of related options, in a scope. For example, the `pytest` subsystem contains options related to [Python's test framework pytest](../../../reference/subsystems/pytest.mdx).
 
-# Setting options
+## Setting options
 
 Every option can be set in the following ways, in order of precedence:
 
@@ -27,7 +27,7 @@ If an option isn't set in one of these ways, it will take on a default value.
 
 You can inspect both the current value and the default value by using `pants help $scope` or `pants help-advanced $scope`, e.g. `pants help global`.
 
-## Command-line flags
+### Command-line flags
 
 Global options are set using an unqualified flag:
 
@@ -41,7 +41,7 @@ Subsystem options are set by providing the flag, with the name prefixed with the
 pants --source-root-patterns="['^ext']"
 ```
 
-## Environment variables
+### Environment variables
 
 Global options are set using the environment variable `PANTS_{OPTION_NAME}`:
 
@@ -58,7 +58,7 @@ PANTS_SOURCE_ROOT_PATTERNS="['^ext']" pants ...
 
 Note that the scope and option name are upper-cased, and any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `MULTIWORD_NAME`.
 
-## Config file entries
+### Config file entries
 
 Global options are set in the `GLOBAL` section of the config file:
 
@@ -76,7 +76,7 @@ root_patterns = ["/src/python"]
 
 Note that any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `multiword_name`.
 
-### Config file interpolation
+#### Config file interpolation
 
 Environment variables can be interpolated by using the syntax `%(env.ENV_VAR)s`, e.g.:
 
@@ -95,7 +95,7 @@ Additionally, a few special values are pre-populated with the `%(var)s` syntax:
 - `%(pants_distdir)s`: absolute path of the global option `--pants-distdir`, which defaults
   to `{buildroot}/dist/`
 
-# Option types
+## Option types
 
 Every option has a type, and any values you set must be of that type.
 
@@ -109,25 +109,25 @@ The option types are:
 
 A list-valued option may also declare a specific type for its members (e.g., a list of strings, or a list of integers).
 
-## String and integer values
+### String and integer values
 
 Standalone string and integer values are written without quotes. Any quotes will be considered part of the value, after shell escaping.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-intopt=42
 pants --scope-stropt=qux
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_INTOPT=42
 PANTS_SCOPE_STROPT=qux
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -135,11 +135,11 @@ intopt = 42
 stropt = "qux"
 ```
 
-## Boolean values
+### Boolean values
 
 Boolean values can be specified using the special strings `true` and `false`. When specifying them via command-line flags you can also use the `--boolopt/--no-boolopt` syntax.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-boolopt=true
@@ -147,24 +147,24 @@ pants --scope-boolopt
 pants --no-scope-boolopt
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_BOOLOPT=true
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
 boolopt = true
 ```
 
-## List values
+### List values
 
 List values are parsed as Python list literals, so you must quote string values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-listopt="['foo','bar']"
@@ -178,7 +178,7 @@ pants --scope-listopt=foo --scope-listopt=bar
 
 Appending will add to any values from lower-precedence sources, such as config files (`pants.toml`) and possibly Pants's `default`. Otherwise, using `[]` will override any lower-precedence sources.
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_LISTOPT="['foo','bar']"
@@ -190,7 +190,7 @@ Like with command-line flags, you can leave off the `[]` to _append_ elements:
 PANTS_SCOPE_LISTOPT=foo
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -200,7 +200,7 @@ listopt = [
 ]
 ```
 
-### Add/remove semantics
+#### Add/remove semantics
 
 List values have some extra semantics:
 
@@ -250,23 +250,23 @@ listopt.remove = [3, 4]
 But note that this only works in Pants's `.toml` config files, not in environment variables or command-line flags.
 :::
 
-## Dict values
+### Dict values
 
 Dict values are parsed as Python dict literals on the command-line and environment variables, so you must quote string keys and values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-dictopt="{'foo':1,'bar':2}"
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_DICTOPT="{'foo':1,'bar':2}"
 ```
 
-### Config file entries:
+#### Config file entries:
 
 You can use TOML's [nested table features](https://toml.io/en/v1.0.0#inline-table). These are equivalent:
 
@@ -291,7 +291,7 @@ dictopt = """{
 }"""
 ```
 
-### Add/replace semantics
+#### Add/replace semantics
 
 - A value can be preceded by `+`, which will _update_ the value obtained from lower-precedence sources with the entries.
 - Otherwise, the value _replaces_ the one obtained from lower-precendence sources.
@@ -310,7 +310,7 @@ pants --scope-dictopt="{'foo':42,'baz':3}"
 
 will set the value to `{'foo': 42, 'baz': 3}`.
 
-# Reading individual option values from files
+## Reading individual option values from files
 
 If an option value is too large or elaborate to use directly, or if you don't want to hard-code
 values directly in `pants.toml`, you can set the value of any option to the string
@@ -345,7 +345,7 @@ do so by `kill`ing it (after using `ps -ef | grep pantsd` to find its pid), or b
 Pants once with `--no-pantsd`.
 :::
 
-# `.pants.rc` file
+## `.pants.rc` file
 
 You can set up personal Pants config files, using the same TOML syntax as `pants.toml`. By default, Pants looks for the paths `/etc/pantsrc`, `~/.pants.rc`, and `.pants.rc` in the repository root.
 

--- a/versioned_docs/version-2.16/docs/using-pants/key-concepts/source-roots.mdx
+++ b/versioned_docs/version-2.16/docs/using-pants/key-concepts/source-roots.mdx
@@ -13,7 +13,7 @@ Go does have a notion of source roots: where your `go.mod` is located. However, 
 Shell does not have any notion of source roots.
 :::
 
-# What are source roots?
+## What are source roots?
 
 Some project layouts use top-level folders for namespace purposes, but have the code live underneath. However, the code's imports will ignore these top-level folders, thanks to mechanisms like the `$PYTHONPATH` and the JVM classpath. _Source roots_ are a generic equivalent of these concepts.
 
@@ -44,7 +44,7 @@ pkgutil.get_data("project.config", "prod.json")
 
 In the example above, `src/python` is a source root. So, when some code says `from project.app import App`, Pants can know that this corresponds to the code in `src/python/project/app.py`.
 
-# Configuring source roots
+## Configuring source roots
 
 There are two ways to configure source roots:
 
@@ -60,7 +60,7 @@ src/python
 src/rust
 ```
 
-## Configuring source roots using patterns
+### Configuring source roots using patterns
 
 You can provide a set of patterns that match your source roots:
 
@@ -85,7 +85,7 @@ You can use `*` as a glob. For example, `root_patterns = ["/src/*"]` would consi
 - `src/java`
 - `src/assets`
 
-### Configuring no source roots
+#### Configuring no source roots
 
 Many projects do not have any top-level folders used for namespacing.
 
@@ -125,7 +125,7 @@ The default value of the `root_patterns` config key is `["/", "src", "src/python
 These capture a range of common cases, including a source root at the root of the repository. If your source roots match these patterns, you don't need to explicitly configure them.
 :::
 
-## Configuring source roots using marker files
+### Configuring source roots using marker files
 
 You can also denote your source roots using specially-named marker files. To do so, first pick a name (or multiple names) to use:
 
@@ -182,15 +182,15 @@ import server.server.app
 from utils.utils.strutil import capitalize
 ```
 
-# Examples
+## Examples
 
 These project structures are all valid; Pants does not expect you to reorganize your codebase to use the tool.
 
-## `src/<lang>` setup
+### `src/<lang>` setup
 
 This setup is common in "polyglot" repositories: i.e. repos with multiple languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -228,7 +228,7 @@ This setup is common in "polyglot" repositories: i.e. repos with multiple langua
 
 While we have tests in a separate source root here, it's also valid to have tests colocated with their src files.
 
-### Example imports:
+#### Example imports:
 
 ```python
 # Python
@@ -242,7 +242,7 @@ import org.pantsbuild.project.App
 import org.pantsbuild.project.util.Math
 ```
 
-### Config:
+#### Config:
 
 ```toml title="pants.toml"
 [source]
@@ -255,9 +255,9 @@ root_patterns = [
 
 Note that we organized our 3rdparty requirements in the top-level folders `3rdparty/python` and `3rdparty/java`, but we do not need to include them as source roots because we do not have any first-party code there.
 
-## Multiple top-level projects
+### Multiple top-level projects
 
-### Project:
+#### Project:
 
 This layout has lots of nesting; this is only one possible way to organize the repository.
 
@@ -289,7 +289,7 @@ This layout has lots of nesting; this is only one possible way to organize the r
         └── spa.js
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 import ads.billing.calculate_bill
@@ -299,7 +299,7 @@ from base.util.math import add_two
 
 Note that even though the projects live in different top-level folders, you are still able to import from other projects. If you would like to limit this, you can use `pants dependents` or `pants dependencies` in CI to track where imports are being used. See [Project introspection](../project-introspection.mdx).
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 
@@ -320,11 +320,11 @@ root_patterns = [
 ]
 ```
 
-## No source root
+### No source root
 
 Warning: while this project structure is valid, it often does not scale as well as your codebase grows, such as adding new languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -340,7 +340,7 @@ Warning: while this project structure is valid, it often does not scale as well 
 └── pyproject.toml
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 from project.app import App
@@ -349,7 +349,7 @@ from project.util.math import add_two
 pkgutil.get_data("project.config", "prod.json")
 ```
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 

--- a/versioned_docs/version-2.16/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/versioned_docs/version-2.16/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -23,7 +23,7 @@ To reduce boilerplate, some targets also generate other targets:
 - `shell_sources` -> `shell_source`
 - `go_mod` -> `go_third_party_package`
 
-# BUILD files
+## BUILD files
 
 Targets are defined in files with the name `BUILD`. For example:
 
@@ -45,7 +45,7 @@ All target types have a `name` field, which is used to identify the target. Targ
 
 You can autoformat `BUILD` files by enabling a `BUILD` file formatter by adding it to `[GLOBAL].backend_packages` in `pants.toml` (such as `pants.backend.build_files.fmt.black` [or others](./backends.mdx)). Then to format, run `pants fmt '**/BUILD'` or `pants fmt ::` (formats everything).
 
-## Environment variables
+### Environment variables
 
 BUILD files are very hermetic in nature with no support for using `import` or other I/O operations. In order to have dynamic data in BUILD files, you may inject values from the local environment using the `env()` function. It takes the variable name and optional default value as arguments.
 
@@ -60,7 +60,7 @@ python_distribution(
 )
 ```
 
-# Target addresses
+## Target addresses
 
 A target is identified by its unique address, in the form `path/to/dir:name`. The above example has the addresses `helloworld/greet:tests` and `helloworld/greet:bin`.
 
@@ -83,7 +83,7 @@ You can refer to this target with either `helloworld/greet:greet` or the abbrevi
 Addressed defined in the `BUILD` file at the root of your repository are prefixed with `//`, e.g. `//:my_tgt`.
 :::
 
-# `source` and `sources` field
+## `source` and `sources` field
 
 Targets like `python_test` and `resource` have a `source: str` field, while target generators like `python_tests` and `resources` have a `sources: list[str]` field. This determines which source files belong to the target.
 
@@ -123,7 +123,7 @@ Including the same file in the `source` / `sources` field for multiple targets c
 You can run `pants list path/to/file.ext` to see all "owning" targets to check if >1 target has the file in its `source` field.
 :::
 
-# `dependencies` field
+## `dependencies` field
 
 A target's dependencies determines which other first-party code and third-party requirements to include when building the target.
 
@@ -166,7 +166,7 @@ You can use the prefix `!!` to transitively exclude a dependency, meaning that e
 Transitive excludes can only be used in target types that conventionally are not dependend upon by other targets, such as `pex_binary` and `python_test` / `python_tests`. This is meant to limit confusion, as using `!!` in something like a `python_source` / `python_sources` target could result in surprising behavior for everything that depends on it. (Pants will print a helpful error when using `!!` when it's not legal.)
 :::
 
-# Field default values
+## Field default values
 
 As mentioned above in [BUILD files](./targets-and-build-files.mdx#build-files), most target fields have sensible defaults. And it's easy to override those values on a specific target. But applying the same non-default value on many targets can get unwieldy, error-prone and hard to maintain. Enter `__defaults__`.
 
@@ -211,7 +211,7 @@ To reset any modified defaults, simply override with the empty dict:
     __defaults__(all={})
 ```
 
-## Supporting optional plugin fields
+### Supporting optional plugin fields
 
 Normally Pants presents an error message when attempting to provide a default value for a field that doesn't exist for the target. However, some fields comes from plugins, and to support disabling a plugin without having to remove any default values referencing any plugin fields it was providing, there is a `ignore_unknown_fields` option to use:
 
@@ -224,7 +224,7 @@ Normally Pants presents an error message when attempting to provide a default va
     )
 ```
 
-## Extending field defaults
+### Extending field defaults
 
 To add to a default value rather than replacing it, the current default value for a target field is available in the BUILD file using `<target>.<field>.default`. This allows you to augment a field's default value with much more precision. As an example, if you want to make the default sources for a `python_sources` target to work recursively you may specify a target augmenting the default sources field:
 
@@ -238,7 +238,7 @@ python_sources(
 )
 ```
 
-# Target generation
+## Target generation
 
 To reduce boilerplate, Pants provides target types that generate other targets. For example:
 
@@ -316,7 +316,7 @@ It's useful for metadata to be as fine-grained as feasible, such as by using the
 [`pants tailor ::`](../../getting-started/initial-configuration.mdx#5-generate-build-files) will automatically create targets that only apply metadata for the directory.
 :::
 
-# Parametrizing targets
+## Parametrizing targets
 
 It can be useful to create multiple targets describing the same entity, each with different metadata. For example:
 

--- a/versioned_docs/version-2.16/docs/using-pants/remote-caching-&-execution/index.mdx
+++ b/versioned_docs/version-2.16/docs/using-pants/remote-caching-&-execution/index.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Overview
+## Overview
 
 By default, Pants executes processes in a local [environment](../environments.mdx) on the system on which it is run, and caches the results of those processes locally as well. Besides this "local execution" mode of operation, Pants also supports two distributed modes of operation:
 
@@ -15,7 +15,7 @@ By default, Pants executes processes in a local [environment](../environments.md
 
 Pants does this by using the "Remote Execution API" to converse with the remote cache or remote execution server.
 
-## What is Remote Execution API?
+### What is Remote Execution API?
 
 Pants is compatible with remote caching and remote execution servers that comply with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI protocol is supported by several different server and client projects including Bazel and of course Pants.
 
@@ -31,7 +31,7 @@ Pants calls the CAS a "store server" and the execution service an "execution ser
 
 The REAPI model contains the notion of an "instance." An "instance" is a distinct deployment of a CAS and/or execution service that is given a specific name. All REAPI operations send an instance name to the server, thus a single network endpoint can conceivably support multiple REAPI deployments.
 
-# Server compatibility
+## Server compatibility
 
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
@@ -54,6 +54,6 @@ Bazel Remote Cache supports local disk, S3, GCS, and Azure Blob storage options 
 There are a few [other](https://github.com/bazelbuild/remote-apis) systems and services in this space, but
 they have not, to our knowledge, been tested with Pants. Let us know if you have any experience with them!
 
-# Resources
+## Resources
 
 - The [remote-apis-testing project](https://gitlab.com/remote-apis-testing/remote-apis-testing) maintains a compatibility test suite of the various server and client implementations of REAPI.

--- a/versioned_docs/version-2.16/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
+++ b/versioned_docs/version-2.16/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
@@ -5,17 +5,17 @@
 
 ---
 
-# What is remote caching?
+## What is remote caching?
 
 Remote caching allows Pants to store and retrieve the results of process execution to and from a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"), rather than only using your machine's local Pants cache. This allows Pants to share a cache across different runs and different machines, for example, all of your CI workers sharing the same fine-grained cache.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote caching requires the availability of a REAPI-compatible cache. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants Configuration
+### Pants Configuration
 
 After you have either set up a REAPI cache server or obtained access to one, the next step is to point Pants to it so that Pants will use it to read and write process results.
 
@@ -31,6 +31,6 @@ remote_instance_name = "main"
 
 If the endpoint is using TLS, then the `remote_store_address` option would be specified with the `grpcs://` scheme, i.e. `"grpcs://cache.corp.example.com:8980"`.
 
-# Reference
+## Reference
 
 Run `pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.

--- a/versioned_docs/version-2.16/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
+++ b/versioned_docs/version-2.16/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
@@ -9,17 +9,17 @@
 Remote execution support in Pants comes with several limitations. For example, Pants requires that the server's operating system match the client's operating system. In practice, this means that Pants must be running on Linux because all three major server projects generally only operate on Linux.
 :::
 
-# What is remote execution?
+## What is remote execution?
 
 "Remote execution" allows Pants to offload execution of processes to a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI standard is supported by several different server and client projects including Bazel and of course Pants.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote execution requires the availability of a REAPI-compatible execution server. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants
+### Pants
 
 After you have either set up a REAPI server or obtained access to one, the next step is to point Pants to it so that Pants may submit REAPI execution requests. The server should be running a CAS and execution service. These may be the same network endpoint, but for Pants' purposes, they are configured by different configuration options.
 
@@ -33,7 +33,7 @@ remote_execution_address = "grpc://build.corp.example.com:8980"
 remote_instance_name = "main"
 ```
 
-### Environment-specific settings
+#### Environment-specific settings
 
 The REAPI execution service selects a worker for a process by consulting the "platform properties" that are passed in a remote execution request. These platform properties are key/value pairs that are configured for particular workers in the server. Generally, you will configure these in the server (or be provided them by your server's administrator), and then configure Pants to match particular workers using their relevant platform properties.
 
@@ -52,7 +52,7 @@ remote_environment(
 
 Your `remote_environment` will also need to override any [environment-aware options](../environments.mdx) which configure the relevant tools used in your repository. For example: if building Python code, a Python interpreter must be available and matched via the environment-aware options of `[python-bootstrap]`. If using protobuf support, then you may also need `unzip` available in the remote execution environment in order to unpack the protoc archive. Etc.
 
-### Concurrency
+#### Concurrency
 
 Finally, you should configure Pants to limit the number of concurrent execution requests that are sent to the REAPI server. The `process_execution_remote_parallelism` option controls this concurrency. For example, if `process_execution_remote_parallelism` is set to `20`, then Pants will only send a maximum of 20 execution requests at a single moment of time.
 
@@ -72,7 +72,7 @@ remote_execution_extra_platform_properties = [
 process_execution_remote_parallelism = 20
 ```
 
-### TLS
+#### TLS
 
 You can enable TLS by prefixing the `remote_store_address` and `remote_execution_address` with `grpcs://` instead of `grpc://`.
 
@@ -90,7 +90,7 @@ remote_instance_name = "main"
 remote_ca_certs_path = "/etc/ssl/certs/ca-certificates.crt"
 ```
 
-# Reference
+## Reference
 
 For global options, run `pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.
 

--- a/versioned_docs/version-2.16/docs/using-pants/validating-dependencies.mdx
+++ b/versioned_docs/version-2.16/docs/using-pants/validating-dependencies.mdx
@@ -76,7 +76,7 @@ backend_packages.add = [
 This does not mean you should not use it, only that it is in "preview" mode meaning that things may change between releases without following our deprecation policy as we work on stabilizing this feature. See [the stabilization ticket](https://github.com/pantsbuild/pants/issues/17634) for what remains to be done for the visibility backend to graduate out of preview.
 :::
 
-# Dependencies and dependents
+## Dependencies and dependents
 
 The visibility rules operates on the dependency link between two targets. Dependencies are directional, so if target `A` depends on another target `B` the dependency goes from the "origin" target `A` -> `B`, we say that `B` is the **dependency** of `A`, while `A` is the **dependent** of `B`.
 
@@ -147,7 +147,7 @@ __dependencies_rules__(
 # Due to the `extend=True` flag, which inherits the parent rules after those just declared.
 ```
 
-## Rule sets
+### Rule sets
 
 As there may be many targets and files with dependencies, odds are that they won't all share the same set of rules. The rules keywords accepts multiple sets of rules, or "rule sets", along with "selector rules" that is used to select which set to use for each target.
 
@@ -250,7 +250,7 @@ The previous example, using this alternative syntax for the selectors, would loo
   )
 ```
 
-## Glob syntax
+### Glob syntax
 
 The visibility rules are all about matching globs. There are two wildcards: the `*` matches anything except `/`, and the `**` matches anything including `/`. (For paths that is non-recursive and recursive globbing respectively.)
 
@@ -280,7 +280,7 @@ some/directory/*
 
 So far the rule globs have been matched from anywhere in the matched to path up to the end. To ensure the path begins with a certain pattern we'd have to provide full paths in our rules, like `src/python/proj/lib/file.py` if we want to make sure that our `file.py` is from the `src/` tree. To avoid lengthy and rigid rule globs hurting refactorings etc, there's a concept of "anchoring" the rule. That will apply the rule glob from a fixed point in the matched to path, and there are three such points: project root, rule declaration path and rule invocation path. The difference between declaration and invocation is explained below.
 
-#### Anchoring mode for path globs
+##### Anchoring mode for path globs
 
 The glob prefix specifies which "anchoring mode" to use, and are:
 
@@ -299,7 +299,7 @@ The glob prefix specifies which "anchoring mode" to use, and are:
 
 > 🚧 Regardless of anchoring mode, all rules are always anchored to the end of the matched path.
 
-#### Targeting non-source files
+##### Targeting non-source files
 
 So far most examples have been about providing rules that match source files. This will likely be the most common scenario, but other targets may just as well need to be considered. For the general case, non-source file targets will be matched using the directory where it has been declared (the path containing the BUILD file in most cases).
 
@@ -350,7 +350,7 @@ __dependencies_rules__(
 )
 ```
 
-## Rule actions
+### Rule actions
 
 When a matching rule is found for a path, the path is either allowed or denied based on the rule's action. The dependency link as a whole is only allowed if both ends of the dependency allow it. By default a rule's action is `ALLOW`, but may be changed to `DENY` or `WARN`. The `WARN` action logs a warning message rather than raising an error, but will otherwise allow the dependency.
 

--- a/versioned_docs/version-2.17/docs/contributions/development/internal-architecture.mdx
+++ b/versioned_docs/version-2.17/docs/contributions/development/internal-architecture.mdx
@@ -5,9 +5,9 @@
 
 ---
 
-# Rule Graph Construction
+## Rule Graph Construction
 
-## Overview
+### Overview
 
 Build logic in [Pants](https://www.pantsbuild.org/) is declared using collections of `@rules` with recursively memoized and invalidated results. This framework (known as Pants' "Engine") has similar goals to Bazel's [Skyframe](https://bazel.build/designs/skyframe.html) and the [Salsa](https://github.com/salsa-rs/salsa) framework: users define logic using a particular API, and the framework manages tracking the dependencies between nodes in a runtime graph.
 
@@ -15,11 +15,11 @@ In order to maximize the amount of work that can be reused at runtime, Pants sta
 
 Concepts used in compilers, including live variable analysis and monomorphization, can also be useful in rule graph construction to minimize rule identities and pre-decide which versions of their dependencies they will use.
 
-## Concepts
+### Concepts
 
 A successfully constructed `RuleGraph` contains a graph where nodes have one of three types, `Rule`s, `Query`s, and `Param`s, which map fairly closely to what a Pants `@rule` author consumes. The edges between nodes represent dependencies: `Query`s are always roots of the graph, `Param`s are always leaves, and `Rule`s represent the end user logic making up all of the internal nodes of the graph.
 
-### Rules
+#### Rules
 
 A `Rule` is a function or coroutine with all of its inputs declared as part of its type signature. The end user type signature is made up of:
 
@@ -31,13 +31,13 @@ In the `RuleGraph`, these are encoded in a [Rule](https://github.com/pantsbuild/
 
 `Rule`s never refer to one another by name (i.e., they do not call one another by name): instead, their signature declares their requirements in terms of input/output types, and rule graph construction decides which potential dependencies will provide those requirements.
 
-### Queries
+#### Queries
 
 The roots/entrypoints of a `RuleGraph` are `Query`s, which should correspond one-to-one to external callsites that use the engine to request that values are computed. A `Query` has an output type, and a series of input types: `Query(output_type, (*input_types))`.
 
 If a user makes a request to the engine that does not have a corresponding `Query` declared, the engine fails rather than attempting to dynamically determine which `Rules` to use to answer the `Query`: how a `RuleGraph` is constructed should show why that is the case.
 
-### Params
+#### Params
 
 `Params` are typed, comparable (`eq`/`hash`) values that represent both the inputs to `Rules`, and the building block of the runtime memoization key for a `Rule`. The set of `Params` (unique by type) that are consumed to create a `Rule`'s inputs (plus the `Rule`'s own identity) make up the memoization key for a runtime instance of the `Rule`.
 
@@ -47,7 +47,7 @@ The `Param`s that are available to a `Rule` are made available by the `Rule`'s d
 
 `Params` flow down the graph from `Query`s and the provided `Param`s of `Get`s: their presence does not need to be re-declared at each intermediate callsite. When a `Rule` consumes a `Param` as a positional argument, that `Param` will no longer be available to that `Rule`'s dependencies (but it might still be present in other subgraphs adjacent to that `Rule`).
 
-## Goals
+### Goals
 
 The goals of `RuleGraph` construction are:
 
@@ -61,7 +61,7 @@ If either of the goals were removed, `RuleGraph` construction might be more stra
 
 But both of the goals are important because together they allow for an API that is easy to write `Rule`s for, with minimal boilerplate required to get the inputs needed for a `Rule` to compute a value, and minimal invalidation. Because the identity of a `Rule` is computed from its transitive input `Param`s rather than from its positional arguments, `Rule`s can accept arbitrarily-many large input values (which don't need to implement hash) with no impact on its memoization hit rate.
 
-## Constraints
+### Constraints
 
 There are a few constraints that decide which `Rule`s are able to provide dependencies for one another:
 
@@ -71,7 +71,7 @@ There are a few constraints that decide which `Rule`s are able to provide depend
 - `provided_params` - When deciding whether one `Rule` can use another `Rule` to provide the output type of a `Get`, a constraint is applied that the candidate depedency must (transitively) consume the `Param` that is provided by the `Get`.
   - For example: if a `Rule` `z` has a `Get(A, B)`, only `Rule`s that compute an `A` and (transitively) consume a `B` are eligible to be used. This also means that a `Param` `A` which is already in scope for `Rule` `z` is not eligible to be used, because it would trivially not consume `B`.
 
-## Implementation
+### Implementation
 
 As of [3a188a1e06](https://github.com/pantsbuild/pants/blob/3a188a1e06d8c27ff86d8c311ff1b2bdea0d39ff/src/rust/engine/rule_graph/src/builder.rs#L202-L219), we construct a `RuleGraph` using a combination of data flow analysis and some homegrown (and likely problematic: see the "Issue Overview") node splitting on the call graph of `Rule`s.
 

--- a/versioned_docs/version-2.17/docs/helm/index.mdx
+++ b/versioned_docs/version-2.17/docs/helm/index.mdx
@@ -11,7 +11,7 @@ Pants has good support for the most common operations for managing Helm charts s
 Please share feedback for what you need to use Pants with your Helm charts by either [opening a GitHub issue](https://github.com/pantsbuild/pants/issues/new/choose) or [joining our Slack](/community/getting-help)!
 :::
 
-# Initial setup
+## Initial setup
 
 First, activate the relevant backend in `pants.toml`:
 
@@ -40,7 +40,7 @@ name: bar
 version: 0.1.0
 ```
 
-## Adding `helm_chart` targets
+### Adding `helm_chart` targets
 
 Helm charts are identified by the presence of a `Chart.yaml` or `Chart.yml` file, which contains relevant metadata about the chart like its name, version, dependencies, etc. To get started quickly you can create a simple `Chart.yaml` file in your sources folder:
 
@@ -63,11 +63,11 @@ Created src/helm/example/BUILD:
   - Add helm_chart target example
 ```
 
-## Basic operations
+### Basic operations
 
 The given setup is enough to now do some common operations on our Helm chart source code.
 
-### Linting
+#### Linting
 
 The Helm backend has an implementation of the Pants' `lint` goal which hooks it with the `helm lint` command:
 
@@ -98,7 +98,7 @@ Likewise, in a similar way you could enable strict linting globally and then cho
 
 You can set the field `skip_lint=True` on each `helm_chart` target to avoid linting it.
 
-### Package
+#### Package
 
 Packing helm charts is supported out of the box via the Pants' `package` goal. The final package will be saved as a `.tgz` file under the `dist` folder at your source root.
 
@@ -111,7 +111,7 @@ Built Helm chart artifact: testprojects.src.helm.example/example/example-0.2.0.t
 
 The final output folder can customised using the `output_path` field in the `helm_chart` target. Run `pants help helm_chart` for more information.
 
-# Helm Unit tests
+## Helm Unit tests
 
 The Helm backend supports running Helm unit tests via the [Helm `unittest` plugin](https://github.com/quintush/helm-unittest). To run unit tests follow the instructions on how to use that plugin and then create a `BUILD` file in the same folder where your tests live with the following target:
 
@@ -159,7 +159,7 @@ pants test ::
 ✓ testprojects/src/helm/example/tests/env-configmap_test.yaml succeeded in 0.75s.
 ```
 
-### Feeding additional files to unit tests
+#### Feeding additional files to unit tests
 
 In some cases we may want our tests to have access to additional files which are not part of the chart. This can be achieved by setting a dependency between our unit test targets and a `resources` target as follows:
 
@@ -262,7 +262,7 @@ not affected by the source roots setting. When using `relocated_files`, the file
 to the value set in the `dest` field.
 :::
 
-### Timeouts
+#### Timeouts
 
 Pants can cancel tests that take too long, which is useful to prevent tests from hanging indefinitely.
 
@@ -296,13 +296,13 @@ If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will 
 
 Use the option `pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
-# Publishing Helm charts
+## Publishing Helm charts
 
 Pants only supports publishing Helm charts to OCI registries, a feature that was made generally available in Helm 3.8.
 
 The publishing is done with Pants' `publish` goal but first you will need to tell Pants what are the possible destination registries where to upload your charts.
 
-## Configuring OCI registries
+### Configuring OCI registries
 
 In a similar way as the `docker_image` target, a `helm_chart` target takes an optional `registries` field whose value is a list of registry endpoints (prefixed by the `oci://` protocol):
 
@@ -350,7 +350,7 @@ helm_chart(
 )
 ```
 
-## Setting a repository name
+### Setting a repository name
 
 When publishing charts into an OCI registry, you most likely will be interested on separating them from other kind of OCI assets (i.e. container images). For doing so you can set a `repository` field in the `helm_chart` target so the chart artifact will be uploaded to the given path:
 
@@ -370,7 +370,7 @@ You can also set a default global repository in `pants.toml` as in the following
 default_registry_repository = "charts"
 ```
 
-# Managing Chart Dependencies
+## Managing Chart Dependencies
 
 Helm charts can depend on other charts, whether first-party charts defined in the same repo, or third-party charts published in a registry. Pants uses this dependency information to know when work needs to be re-run.
 
@@ -378,7 +378,7 @@ Helm charts can depend on other charts, whether first-party charts defined in th
 To benefit from Pants dependency management and inference in your Helm charts, you will need to use `apiVersion: v2` in your `Chart.yaml` file.
 :::
 
-## `Chart.yaml` dependencies
+### `Chart.yaml` dependencies
 
 Pants will automatically infer dependencies from the `Chart.yaml` file.
 
@@ -415,7 +415,7 @@ pants dependencies src/helm/bar
 src/helm/foo
 ```
 
-## Explicitly provided dependencies in `BUILD` files
+### Explicitly provided dependencies in `BUILD` files
 
 If you prefer, you can let your BUILD files be the "source of truth" for dependencies, instead of specifying them in `Chart.yaml`:
 
@@ -443,7 +443,7 @@ helm_chart(dependencies=["//src/helm/foo"])
 
 In this case, the `pants dependencies` command will show the same result and, in addition, Pants will modify its copy of `bar`'s `Chart.yaml` before using it, so that it includes `foo` in its dependency list. Note that Pants will not modify the original copy in your source tree, only the copy it uses in the sandboxed execution environment.
 
-## Third party chart artifacts
+### Third party chart artifacts
 
 Third party charts are provided to Pants using the `helm_artifact` target:
 

--- a/versioned_docs/version-2.17/docs/introduction/welcome-to-pants.mdx
+++ b/versioned_docs/version-2.17/docs/introduction/welcome-to-pants.mdx
@@ -5,11 +5,11 @@
 
 ---
 
-# What is Pants?
+## What is Pants?
 
 Pants is a fast, scalable, user-friendly build and developer workflow system for codebases of all sizes, including yours!
 
-# What does Pants do?
+## What does Pants do?
 
 Pants installs, orchestrates and runs dozens of standard underlying tools - compilers, code generators, dependency resolvers, test runners, linters, formatters, packagers, REPLs and more - composing them into a single stable, hermetic toolchain, and speeding up your workflows via caching and concurrency.
 
@@ -17,13 +17,13 @@ Pants is designed to be easy to adopt, use, and extend. It doesn't require you t
 
 Pants is currently focused on Python, Go, Java, Scala, Shell, and Docker, with more languages and frameworks coming soon. [The Pants community](/community/members) is friendly and helpful and welcomes involvement of anyone who is interested in creating modern software development tooling.
 
-# Who is Pants for?
+## Who is Pants for?
 
 Pants is useful for repos of all sizes, but is particularly valuable for those containing multiple distinct but interdependent pieces.
 
 Pants works well with (but does not require) a [_monorepo_ architecture](https://blog.pantsbuild.org/the-monorepo-approach-to-code-management/): a codebase containing multiple projects—often using multiple programming languages and frameworks—in a single unified repository. If you want to scale your codebase without breaking it up into multiple disconnected repos, with all the versioning and maintenance headaches that causes, Pants provides the tooling for you to do so effectively.
 
-# What are the main features of Pants?
+## What are the main features of Pants?
 
 Pants is designed for fast, consistent, ergonomic builds. Some noteworthy features include:
 
@@ -36,7 +36,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 - Extensibility and customizability via a plugin API
 - Code introspection features
 
-# Which languages and frameworks does Pants support?
+## Which languages and frameworks does Pants support?
 
 - Pants [ships](page:language-support) with support for [Python](../python/overview/index.mdx), [Go](../go/index.mdx), [Java](../java-and-scala/index.mdx), [Scala](../java-and-scala/index.mdx) and [Shell](../shell/index.mdx).
 - Pants supports a wide range of code generators (such as Thrift, Protobuf, Scrooge and Avro), linters and formatters, and it is easy to add support for new or custom ones
@@ -45,7 +45,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 We're listening to the community for which languages, frameworks and tools we should support next, so let us know about your needs by [opening an issue](https://github.com/pantsbuild/pants/issues/new/choose) on GitHub or [chatting with us](/community/members) about it on the community Slack!
 Pants was designed for extensibility, and we welcome [contributions](../contributions/index.mdx)!
 
-# How does Pants work?
+## How does Pants work?
 
 The core of Pants is its execution engine, which sequences and coordinates all the underlying work. The engine is written in Rust, for performance. The underlying work is performed by executing _rules_, which are typed Python 3 async coroutines for familiarity and simplicity.
 
@@ -53,17 +53,17 @@ The engine is designed so that fine-grained invalidation, concurrency, hermetici
 
 See [here](./how-does-pants-work.mdx) for more details about the Pants engine.
 
-# Is Pants similar to X?
+## Is Pants similar to X?
 
 Pants (v2) is a leap forward in the evolution of build systems, a category that runs from the venerable Make through Ant, Maven, Gradle and SBT, to Bazel, Please, Buck, Pants v1 and others.
 
 Its design leans on ideas and inspiration from these earlier tools, while optimizing not just for speed and correctness, but also for ease of adoption, ease of use and ease of extension, all for real-world use cases at a variety of teams.
 
-# Who uses Pants?
+## Who uses Pants?
 
 Pants is making engineering teams productive and happy at a range of companies and organizations. See a sample of them [here](page:who-uses-pants)!
 
-# Who develops Pants?
+## Who develops Pants?
 
 Pants is an open-source software project, developed at [github.com/pantsbuild/pants](https://github.com/pantsbuild/pants). Pants is released under the [Apache License 2.0](https://github.com/pantsbuild/pants/blob/master/LICENSE).
 

--- a/versioned_docs/version-2.17/docs/using-pants/environments.mdx
+++ b/versioned_docs/version-2.17/docs/using-pants/environments.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Environments
+## Environments
 
 :::caution Environments are currently in `preview`, and have not yet stabilized.
 We'd love your feedback on how Environments could be most useful to you! Please refer to [the tracking issue](https://github.com/pantsbuild/pants/issues/17355) for known stabilization blockers.
@@ -17,7 +17,7 @@ By default, Pants will execute all sandboxed build work directly on localhost. B
 2. remotely via [remote execution](./remote-caching-&-execution/remote-execution.mdx)
 3. locally, but with a non-default set of environment variables and settings (such as when different platforms need different values, or when cross-building)
 
-## Defining environments
+### Defining environments
 
 Environments are defined using environment targets:
 
@@ -49,7 +49,7 @@ docker_environment(
 )
 ```
 
-### Environment-aware options
+#### Environment-aware options
 
 Environment targets have fields ([target](./key-concepts/targets-and-build-files.mdx) arguments) which correspond to [options](./key-concepts/options.mdx) which are marked "environment-aware". When an option is environment-aware, the value of the option that will be used in an environment can be overridden by setting the corresponding field value on the associated environment target. If an environment target does not set a value, it defaults to the value which is set globally via options values.
 
@@ -59,7 +59,7 @@ For example, the [`[python-bootstrap].search_path` option](../../reference/subsy
 Environments are a new concept: if you see an option value which should be marked environment-aware but isn't, please definitely [file an issue](https://github.com/pantsbuild/pants/issues/new/choose)!
 :::
 
-## Consuming environments
+### Consuming environments
 
 To declare which environment they should build with, many target types (but particularly "root" targets like tests or binaries) have an `environment=` field: for example, [`python_tests(environment=..)`](../../reference/targets/python_tests.mdx#environment).
 
@@ -74,7 +74,7 @@ Currently, there is no static validation that a target's environment is compatib
 As we gain more experience with how environments are used in the wild, it's possible that more static validation can be added: your feedback would be very welcome!
 :::
 
-### Setting the environment on many targets at once
+#### Setting the environment on many targets at once
 
 To use an environment everywhere in your repository (or only within a particular subdirectory, or with a particular target
 type), you can use the [`__defaults__` builtin](./key-concepts/targets-and-build-files.mdx#field-default-values). For example, to use an environment named `my_default_environment` globally by default, you would add the following to a `BUILD` file at the root of the repository:
@@ -85,7 +85,7 @@ __defaults__(all=dict(environment="my_default_environment"))
 
 ... and individual targets could override the default as needed.
 
-### Building one target in multiple environments
+#### Building one target in multiple environments
 
 If a target will always need to be built in multiple environments (rather than conditionally based on which user is building it: see the "Toggle use of an environment for some consumers" section), then you can use the [`parametrize` builtin](./key-concepts/targets-and-build-files.mdx#parametrizing-targets) for the `environment=` field. If you had two environments named `linux` and `macos`, that would look like:
 
@@ -96,7 +96,7 @@ pex_binary(
 )
 ```
 
-### Environment matching
+#### Environment matching
 
 A single environment name may end up referring to different environment targets on different physical machines, or with different global settings applied: this is known as environment "matching".
 
@@ -129,9 +129,9 @@ docker_environment(
 
 In future versions, environment targets will gain additional predicates to control whether they match (for example: `local_environment` will likely gain a predicate that looks for the [presence or value of an environment variable](https://github.com/pantsbuild/pants/issues/17107). But in the meantime, it's possible to override which environments are matched for particular use cases by overriding their configured names: see the "Toggle use of an environment" workflow below for an example.
 
-## Example workflows
+### Example workflows
 
-### Enabling remote execution globally
+#### Enabling remote execution globally
 
 `remote_environment` targets match unless the [`--remote-execution`](../../reference/global-options.mdx#remote_execution) option is disabled. So to cause a particular environment name to use remote execution whenever it is enabled, you could define environment targets which try remote execution first, and then fall back to local execution:
 
@@ -163,7 +163,7 @@ local = "//:local"
 The `2.15.x` series of Pants does not yet support ["speculating" remote execution](https://github.com/pantsbuild/pants/issues/8353) by racing it against another environment (usually local or docker). While we expect that this will be necessary to make remote execution a viable option for local execution on user's laptops (where network connections are less reliable), it is less critical for CI use-cases.
 :::
 
-### Use a `docker_environment` to build the inputs to a `docker_image`
+#### Use a `docker_environment` to build the inputs to a `docker_image`
 
 To build a `docker_image` target containing a `pex_binary` which uses native (i.e. compiled) dependencies on a `macOS` machine, you can configure the `pex_binary` to be built in a `docker_environment`.
 
@@ -202,7 +202,7 @@ Note that the Docker image used in your `docker_environment` does not need to ma
 This means that your `docker_environment` can include things like compilers or other tools relevant to your build, without needing to manually use multi-stage Docker builds.
 :::
 
-### Toggle use of an environment for some consumers
+#### Toggle use of an environment for some consumers
 
 As mentioned above in "Environment matching", environment targets "match" based on their field values and global options. But if two environment targets would be ambiguous in some cases, or if you'd otherwise like to control what a particular environment name means (in CI, for example), you can override an environment name via options.
 

--- a/versioned_docs/version-2.17/docs/using-pants/key-concepts/goals.mdx
+++ b/versioned_docs/version-2.17/docs/using-pants/key-concepts/goals.mdx
@@ -17,7 +17,7 @@ To see the current list of goals, run:
 
 You'll see more goals activated as you activate more [backends](./backends.mdx).
 
-# Running goals
+## Running goals
 
 For example:
 
@@ -49,7 +49,7 @@ sequentially, and then Pants will wait until a relevant file has changed to try 
 
 Use `Ctrl+C` to exit the `--loop`.
 
-# Goal arguments
+## Goal arguments
 
 Most goals require arguments to know what to work on.
 
@@ -76,7 +76,7 @@ This will become the default in Pants 2.14.
 See [Advanced target selection](../advanced-target-selection.mdx) for alternative techniques to specify which files/targets to run on.
 :::
 
-## Goal options
+### Goal options
 
 Many goals also have [options](./options.mdx) to change how they behave. Every option in Pants can be set via an environment variable, config file, and the command line.
 

--- a/versioned_docs/version-2.17/docs/using-pants/key-concepts/options.mdx
+++ b/versioned_docs/version-2.17/docs/using-pants/key-concepts/options.mdx
@@ -7,7 +7,7 @@ A deep dive into how options may be configured.
 
 ---
 
-# Option scopes
+## Option scopes
 
 Options are partitioned into named _scopes_.
 
@@ -15,7 +15,7 @@ Some systemwide options belong in the _global scope_. For example, the `--level`
 
 Other options belong to a _subsystem scope_. A _subsystem_ is simply a collection of related options, in a scope. For example, the `pytest` subsystem contains options related to [Python's test framework pytest](../../../reference/subsystems/pytest.mdx).
 
-# Setting options
+## Setting options
 
 Every option can be set in the following ways, in order of precedence:
 
@@ -27,7 +27,7 @@ If an option isn't set in one of these ways, it will take on a default value.
 
 You can inspect both the current value and the default value by using `pants help $scope` or `pants help-advanced $scope`, e.g. `pants help global`.
 
-## Command-line flags
+### Command-line flags
 
 Global options are set using an unqualified flag:
 
@@ -41,7 +41,7 @@ Subsystem options are set by providing the flag, with the name prefixed with the
 pants --source-root-patterns="['^ext']"
 ```
 
-## Environment variables
+### Environment variables
 
 Global options are set using the environment variable `PANTS_{OPTION_NAME}`:
 
@@ -58,7 +58,7 @@ PANTS_SOURCE_ROOT_PATTERNS="['^ext']" pants ...
 
 Note that the scope and option name are upper-cased, and any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `MULTIWORD_NAME`.
 
-## Config file entries
+### Config file entries
 
 Global options are set in the `GLOBAL` section of the config file:
 
@@ -76,7 +76,7 @@ root_patterns = ["/src/python"]
 
 Note that any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `multiword_name`.
 
-### Config file interpolation
+#### Config file interpolation
 
 Environment variables can be interpolated by using the syntax `%(env.ENV_VAR)s`, e.g.:
 
@@ -95,7 +95,7 @@ Additionally, a few special values are pre-populated with the `%(var)s` syntax:
 - `%(pants_distdir)s`: absolute path of the global option `--pants-distdir`, which defaults
   to `{buildroot}/dist/`
 
-# Option types
+## Option types
 
 Every option has a type, and any values you set must be of that type.
 
@@ -109,25 +109,25 @@ The option types are:
 
 A list-valued option may also declare a specific type for its members (e.g., a list of strings, or a list of integers).
 
-## String and integer values
+### String and integer values
 
 Standalone string and integer values are written without quotes. Any quotes will be considered part of the value, after shell escaping.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-intopt=42
 pants --scope-stropt=qux
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_INTOPT=42
 PANTS_SCOPE_STROPT=qux
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -135,11 +135,11 @@ intopt = 42
 stropt = "qux"
 ```
 
-## Boolean values
+### Boolean values
 
 Boolean values can be specified using the special strings `true` and `false`. When specifying them via command-line flags you can also use the `--boolopt/--no-boolopt` syntax.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-boolopt=true
@@ -147,24 +147,24 @@ pants --scope-boolopt
 pants --no-scope-boolopt
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_BOOLOPT=true
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
 boolopt = true
 ```
 
-## List values
+### List values
 
 List values are parsed as Python list literals, so you must quote string values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-listopt="['foo','bar']"
@@ -178,7 +178,7 @@ pants --scope-listopt=foo --scope-listopt=bar
 
 Appending will add to any values from lower-precedence sources, such as config files (`pants.toml`) and possibly Pants's `default`. Otherwise, using `[]` will override any lower-precedence sources.
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_LISTOPT="['foo','bar']"
@@ -190,7 +190,7 @@ Like with command-line flags, you can leave off the `[]` to _append_ elements:
 PANTS_SCOPE_LISTOPT=foo
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -200,7 +200,7 @@ listopt = [
 ]
 ```
 
-### Add/remove semantics
+#### Add/remove semantics
 
 List values have some extra semantics:
 
@@ -250,23 +250,23 @@ listopt.remove = [3, 4]
 But note that this only works in Pants's `.toml` config files, not in environment variables or command-line flags.
 :::
 
-## Dict values
+### Dict values
 
 Dict values are parsed as Python dict literals on the command-line and environment variables, so you must quote string keys and values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-dictopt="{'foo':1,'bar':2}"
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_DICTOPT="{'foo':1,'bar':2}"
 ```
 
-### Config file entries:
+#### Config file entries:
 
 You can use TOML's [nested table features](https://toml.io/en/v1.0.0#inline-table). These are equivalent:
 
@@ -291,7 +291,7 @@ dictopt = """{
 }"""
 ```
 
-### Add/replace semantics
+#### Add/replace semantics
 
 - A value can be preceded by `+`, which will _update_ the value obtained from lower-precedence sources with the entries.
 - Otherwise, the value _replaces_ the one obtained from lower-precendence sources.
@@ -310,7 +310,7 @@ pants --scope-dictopt="{'foo':42,'baz':3}"
 
 will set the value to `{'foo': 42, 'baz': 3}`.
 
-# Reading individual option values from files
+## Reading individual option values from files
 
 If an option value is too large or elaborate to use directly, or if you don't want to hard-code
 values directly in `pants.toml`, you can set the value of any option to the string
@@ -345,7 +345,7 @@ do so by `kill`ing it (after using `ps -ef | grep pantsd` to find its pid), or b
 Pants once with `--no-pantsd`.
 :::
 
-# `.pants.rc` file
+## `.pants.rc` file
 
 You can set up personal Pants config files, using the same TOML syntax as `pants.toml`. By default, Pants looks for the paths `/etc/pantsrc`, `~/.pants.rc`, and `.pants.rc` in the repository root.
 

--- a/versioned_docs/version-2.17/docs/using-pants/key-concepts/source-roots.mdx
+++ b/versioned_docs/version-2.17/docs/using-pants/key-concepts/source-roots.mdx
@@ -13,7 +13,7 @@ Go does have a notion of source roots: where your `go.mod` is located. However, 
 Shell does not have any notion of source roots.
 :::
 
-# What are source roots?
+## What are source roots?
 
 Some project layouts use top-level folders for namespace purposes, but have the code live underneath. However, the code's imports will ignore these top-level folders, thanks to mechanisms like the `$PYTHONPATH` and the JVM classpath. _Source roots_ are a generic equivalent of these concepts.
 
@@ -44,7 +44,7 @@ pkgutil.get_data("project.config", "prod.json")
 
 In the example above, `src/python` is a source root. So, when some code says `from project.app import App`, Pants can know that this corresponds to the code in `src/python/project/app.py`.
 
-# Configuring source roots
+## Configuring source roots
 
 There are two ways to configure source roots:
 
@@ -60,7 +60,7 @@ src/python
 src/rust
 ```
 
-## Configuring source roots using patterns
+### Configuring source roots using patterns
 
 You can provide a set of patterns that match your source roots:
 
@@ -85,7 +85,7 @@ You can use `*` as a glob. For example, `root_patterns = ["/src/*"]` would consi
 - `src/java`
 - `src/assets`
 
-### Configuring no source roots
+#### Configuring no source roots
 
 Many projects do not have any top-level folders used for namespacing.
 
@@ -125,7 +125,7 @@ The default value of the `root_patterns` config key is `["/", "src", "src/python
 These capture a range of common cases, including a source root at the root of the repository. If your source roots match these patterns, you don't need to explicitly configure them.
 :::
 
-## Configuring source roots using marker files
+### Configuring source roots using marker files
 
 You can also denote your source roots using specially-named marker files. To do so, first pick a name (or multiple names) to use:
 
@@ -182,15 +182,15 @@ import server.server.app
 from utils.utils.strutil import capitalize
 ```
 
-# Examples
+## Examples
 
 These project structures are all valid; Pants does not expect you to reorganize your codebase to use the tool.
 
-## `src/<lang>` setup
+### `src/<lang>` setup
 
 This setup is common in "polyglot" repositories: i.e. repos with multiple languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -228,7 +228,7 @@ This setup is common in "polyglot" repositories: i.e. repos with multiple langua
 
 While we have tests in a separate source root here, it's also valid to have tests colocated with their src files.
 
-### Example imports:
+#### Example imports:
 
 ```python
 # Python
@@ -242,7 +242,7 @@ import org.pantsbuild.project.App
 import org.pantsbuild.project.util.Math
 ```
 
-### Config:
+#### Config:
 
 ```toml title="pants.toml"
 [source]
@@ -255,9 +255,9 @@ root_patterns = [
 
 Note that we organized our 3rdparty requirements in the top-level folders `3rdparty/python` and `3rdparty/java`, but we do not need to include them as source roots because we do not have any first-party code there.
 
-## Multiple top-level projects
+### Multiple top-level projects
 
-### Project:
+#### Project:
 
 This layout has lots of nesting; this is only one possible way to organize the repository.
 
@@ -289,7 +289,7 @@ This layout has lots of nesting; this is only one possible way to organize the r
         └── spa.js
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 import ads.billing.calculate_bill
@@ -299,7 +299,7 @@ from base.util.math import add_two
 
 Note that even though the projects live in different top-level folders, you are still able to import from other projects. If you would like to limit this, you can use `pants dependents` or `pants dependencies` in CI to track where imports are being used. See [Project introspection](../project-introspection.mdx).
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 
@@ -320,11 +320,11 @@ root_patterns = [
 ]
 ```
 
-## No source root
+### No source root
 
 Warning: while this project structure is valid, it often does not scale as well as your codebase grows, such as adding new languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -340,7 +340,7 @@ Warning: while this project structure is valid, it often does not scale as well 
 └── pyproject.toml
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 from project.app import App
@@ -349,7 +349,7 @@ from project.util.math import add_two
 pkgutil.get_data("project.config", "prod.json")
 ```
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 

--- a/versioned_docs/version-2.17/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/versioned_docs/version-2.17/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -23,7 +23,7 @@ To reduce boilerplate, some targets also generate other targets:
 - `shell_sources` -> `shell_source`
 - `go_mod` -> `go_third_party_package`
 
-# BUILD files
+## BUILD files
 
 Targets are defined in files with the name `BUILD`. For example:
 
@@ -45,7 +45,7 @@ All target types have a `name` field, which is used to identify the target. Targ
 
 You can autoformat `BUILD` files by enabling a `BUILD` file formatter by adding it to `[GLOBAL].backend_packages` in `pants.toml` (such as `pants.backend.build_files.fmt.black` [or others](./backends.mdx)). Then to format, run `pants fmt '**/BUILD'` or `pants fmt ::` (formats everything).
 
-## Environment variables
+### Environment variables
 
 BUILD files are very hermetic in nature with no support for using `import` or other I/O operations. In order to have dynamic data in BUILD files, you may inject values from the local environment using the `env()` function. It takes the variable name and optional default value as arguments.
 
@@ -60,7 +60,7 @@ python_distribution(
 )
 ```
 
-# Target addresses
+## Target addresses
 
 A target is identified by its unique address, in the form `path/to/dir:name`. The above example has the addresses `helloworld/greet:tests` and `helloworld/greet:bin`.
 
@@ -83,7 +83,7 @@ You can refer to this target with either `helloworld/greet:greet` or the abbrevi
 Addressed defined in the `BUILD` file at the root of your repository are prefixed with `//`, e.g. `//:my_tgt`.
 :::
 
-# `source` and `sources` field
+## `source` and `sources` field
 
 Targets like `python_test` and `resource` have a `source: str` field, while target generators like `python_tests` and `resources` have a `sources: list[str]` field. This determines which source files belong to the target.
 
@@ -123,7 +123,7 @@ Including the same file in the `source` / `sources` field for multiple targets c
 You can run `pants list path/to/file.ext` to see all "owning" targets to check if >1 target has the file in its `source` field.
 :::
 
-# `dependencies` field
+## `dependencies` field
 
 A target's dependencies determines which other first-party code and third-party requirements to include when building the target.
 
@@ -166,7 +166,7 @@ You can use the prefix `!!` to transitively exclude a dependency, meaning that e
 Transitive excludes can only be used in target types that conventionally are not dependend upon by other targets, such as `pex_binary` and `python_test` / `python_tests`. This is meant to limit confusion, as using `!!` in something like a `python_source` / `python_sources` target could result in surprising behavior for everything that depends on it. (Pants will print a helpful error when using `!!` when it's not legal.)
 :::
 
-# Field default values
+## Field default values
 
 As mentioned above in [BUILD files](./targets-and-build-files.mdx#build-files), most target fields have sensible defaults. And it's easy to override those values on a specific target. But applying the same non-default value on many targets can get unwieldy, error-prone and hard to maintain. Enter `__defaults__`.
 
@@ -211,7 +211,7 @@ To reset any modified defaults, simply override with the empty dict:
     __defaults__(all={})
 ```
 
-## Supporting optional plugin fields
+### Supporting optional plugin fields
 
 Normally Pants presents an error message when attempting to provide a default value for a field that doesn't exist for the target. However, some fields comes from plugins, and to support disabling a plugin without having to remove any default values referencing any plugin fields it was providing, there is a `ignore_unknown_fields` option to use:
 
@@ -224,7 +224,7 @@ Normally Pants presents an error message when attempting to provide a default va
     )
 ```
 
-## Extending field defaults
+### Extending field defaults
 
 To add to a default value rather than replacing it, the current default value for a target field is available in the BUILD file using `<target>.<field>.default`. This allows you to augment a field's default value with much more precision. As an example, if you want to make the default sources for a `python_sources` target to work recursively you may specify a target augmenting the default sources field:
 
@@ -238,7 +238,7 @@ python_sources(
 )
 ```
 
-# Target generation
+## Target generation
 
 To reduce boilerplate, Pants provides target types that generate other targets. For example:
 
@@ -316,7 +316,7 @@ It's useful for metadata to be as fine-grained as feasible, such as by using the
 [`pants tailor ::`](../../getting-started/initial-configuration.mdx#5-generate-build-files) will automatically create targets that only apply metadata for the directory.
 :::
 
-# Parametrizing targets
+## Parametrizing targets
 
 It can be useful to create multiple targets describing the same entity, each with different metadata. For example:
 

--- a/versioned_docs/version-2.17/docs/using-pants/remote-caching-&-execution/index.mdx
+++ b/versioned_docs/version-2.17/docs/using-pants/remote-caching-&-execution/index.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Overview
+## Overview
 
 By default, Pants executes processes in a local [environment](../environments.mdx) on the system on which it is run, and caches the results of those processes locally as well. Besides this "local execution" mode of operation, Pants also supports two distributed modes of operation:
 
@@ -15,7 +15,7 @@ By default, Pants executes processes in a local [environment](../environments.md
 
 Pants does this by using the "Remote Execution API" to converse with the remote cache or remote execution server.
 
-## What is Remote Execution API?
+### What is Remote Execution API?
 
 Pants is compatible with remote caching and remote execution servers that comply with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI protocol is supported by several different server and client projects including Bazel and of course Pants.
 
@@ -31,7 +31,7 @@ Pants calls the CAS a "store server" and the execution service an "execution ser
 
 The REAPI model contains the notion of an "instance." An "instance" is a distinct deployment of a CAS and/or execution service that is given a specific name. All REAPI operations send an instance name to the server, thus a single network endpoint can conceivably support multiple REAPI deployments.
 
-# Server compatibility
+## Server compatibility
 
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
@@ -54,6 +54,6 @@ Bazel Remote Cache supports local disk, S3, GCS, and Azure Blob storage options 
 There are a few [other](https://github.com/bazelbuild/remote-apis) systems and services in this space, but
 they have not, to our knowledge, been tested with Pants. Let us know if you have any experience with them!
 
-# Resources
+## Resources
 
 - The [remote-apis-testing project](https://gitlab.com/remote-apis-testing/remote-apis-testing) maintains a compatibility test suite of the various server and client implementations of REAPI.

--- a/versioned_docs/version-2.17/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
+++ b/versioned_docs/version-2.17/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
@@ -5,17 +5,17 @@
 
 ---
 
-# What is remote caching?
+## What is remote caching?
 
 Remote caching allows Pants to store and retrieve the results of process execution to and from a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"), rather than only using your machine's local Pants cache. This allows Pants to share a cache across different runs and different machines, for example, all of your CI workers sharing the same fine-grained cache.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote caching requires the availability of a REAPI-compatible cache. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants Configuration
+### Pants Configuration
 
 After you have either set up a REAPI cache server or obtained access to one, the next step is to point Pants to it so that Pants will use it to read and write process results.
 
@@ -31,6 +31,6 @@ remote_instance_name = "main"
 
 If the endpoint is using TLS, then the `remote_store_address` option would be specified with the `grpcs://` scheme, i.e. `"grpcs://cache.corp.example.com:8980"`.
 
-# Reference
+## Reference
 
 Run `pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.

--- a/versioned_docs/version-2.17/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
+++ b/versioned_docs/version-2.17/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
@@ -9,17 +9,17 @@
 Remote execution support in Pants comes with several limitations. For example, Pants requires that the server's operating system match the client's operating system. In practice, this means that Pants must be running on Linux because all three major server projects generally only operate on Linux.
 :::
 
-# What is remote execution?
+## What is remote execution?
 
 "Remote execution" allows Pants to offload execution of processes to a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI standard is supported by several different server and client projects including Bazel and of course Pants.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote execution requires the availability of a REAPI-compatible execution server. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants
+### Pants
 
 After you have either set up a REAPI server or obtained access to one, the next step is to point Pants to it so that Pants may submit REAPI execution requests. The server should be running a CAS and execution service. These may be the same network endpoint, but for Pants' purposes, they are configured by different configuration options.
 
@@ -33,7 +33,7 @@ remote_execution_address = "grpc://build.corp.example.com:8980"
 remote_instance_name = "main"
 ```
 
-### Environment-specific settings
+#### Environment-specific settings
 
 The REAPI execution service selects a worker for a process by consulting the "platform properties" that are passed in a remote execution request. These platform properties are key/value pairs that are configured for particular workers in the server. Generally, you will configure these in the server (or be provided them by your server's administrator), and then configure Pants to match particular workers using their relevant platform properties.
 
@@ -52,7 +52,7 @@ remote_environment(
 
 Your `remote_environment` will also need to override any [environment-aware options](../environments.mdx) which configure the relevant tools used in your repository. For example: if building Python code, a Python interpreter must be available and matched via the environment-aware options of `[python-bootstrap]`. If using protobuf support, then you may also need `unzip` available in the remote execution environment in order to unpack the protoc archive. Etc.
 
-### Concurrency
+#### Concurrency
 
 Finally, you should configure Pants to limit the number of concurrent execution requests that are sent to the REAPI server. The `process_execution_remote_parallelism` option controls this concurrency. For example, if `process_execution_remote_parallelism` is set to `20`, then Pants will only send a maximum of 20 execution requests at a single moment of time.
 
@@ -72,7 +72,7 @@ remote_execution_extra_platform_properties = [
 process_execution_remote_parallelism = 20
 ```
 
-### TLS
+#### TLS
 
 You can enable TLS by prefixing the `remote_store_address` and `remote_execution_address` with `grpcs://` instead of `grpc://`.
 
@@ -90,7 +90,7 @@ remote_instance_name = "main"
 remote_ca_certs_path = "/etc/ssl/certs/ca-certificates.crt"
 ```
 
-# Reference
+## Reference
 
 For global options, run `pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.
 

--- a/versioned_docs/version-2.17/docs/using-pants/validating-dependencies.mdx
+++ b/versioned_docs/version-2.17/docs/using-pants/validating-dependencies.mdx
@@ -76,7 +76,7 @@ backend_packages.add = [
 This does not mean you should not use it, only that it is in "preview" mode meaning that things may change between releases without following our deprecation policy as we work on stabilizing this feature. See [the stabilization ticket](https://github.com/pantsbuild/pants/issues/17634) for what remains to be done for the visibility backend to graduate out of preview.
 :::
 
-# Dependencies and dependents
+## Dependencies and dependents
 
 The visibility rules operates on the dependency link between two targets. Dependencies are directional, so if target `A` depends on another target `B` the dependency goes from the "origin" target `A` -> `B`, we say that `B` is the **dependency** of `A`, while `A` is the **dependent** of `B`.
 
@@ -174,7 +174,7 @@ __dependencies_rules__(
 
 The above rules when applied to `resources` _as well as_ `files` targets in `src/subdir` will allow dependencies only to other targets in the subtree of `src/subdir/relative/to/BUILD/file/` despite the inherited rule declared in `src/BUILD`. For `files` targets in other directories in the `src/` subtree (e.g. `src/another/dir`) dependencies will be allowed only to other targets in the subtree of `src/relative/to/BUILD/file/`.
 
-## Rule sets
+### Rule sets
 
 As there may be many targets and files with dependencies, odds are that they won't all share the same set of rules. The rules keywords accepts multiple sets of rules, or "rule sets", along with "selector rules" that is used to select which set to use for each target.
 
@@ -283,7 +283,7 @@ The previous example, using this alternative syntax for the selectors, would loo
   )
 ```
 
-## Glob syntax
+### Glob syntax
 
 The visibility rules are all about matching globs. There are two wildcards: the `*` matches anything except `/`, and the `**` matches anything including `/`. (For paths that is non-recursive and recursive globbing respectively.)
 
@@ -313,7 +313,7 @@ some/directory/*
 
 So far the rule globs have been matched from anywhere in the matched to path up to the end. To ensure the path begins with a certain pattern we'd have to provide full paths in our rules, like `src/python/proj/lib/file.py` if we want to make sure that our `file.py` is from the `src/` tree. To avoid lengthy and rigid rule globs hurting refactorings etc, there's a concept of "anchoring" the rule. That will apply the rule glob from a fixed point in the matched to path, and there are three such points: project root, rule declaration path and rule invocation path. The difference between declaration and invocation is explained below.
 
-#### Anchoring mode for path globs
+##### Anchoring mode for path globs
 
 The glob prefix specifies which "anchoring mode" to use, and are:
 
@@ -334,7 +334,7 @@ The glob prefix specifies which "anchoring mode" to use, and are:
 
 > 🚧 Regardless of anchoring mode, all rules are always anchored to the end of the matched path.
 
-#### Targeting non-source files
+##### Targeting non-source files
 
 So far most examples have been about providing rules that match source files. This will likely be the most common scenario, but other targets may just as well need to be considered. For the general case, non-source file targets will be matched using the directory where it has been declared (the path containing the BUILD file in most cases).
 
@@ -385,7 +385,7 @@ __dependencies_rules__(
 )
 ```
 
-## Rule actions
+### Rule actions
 
 When a matching rule is found for a path, the path is either allowed or denied based on the rule's action. The dependency link as a whole is only allowed if both ends of the dependency allow it. By default a rule's action is `ALLOW`, but may be changed to `DENY` or `WARN`. The `WARN` action logs a warning message rather than raising an error, but will otherwise allow the dependency.
 

--- a/versioned_docs/version-2.18/docs/contributions/development/internal-architecture.mdx
+++ b/versioned_docs/version-2.18/docs/contributions/development/internal-architecture.mdx
@@ -5,9 +5,9 @@
 
 ---
 
-# Rule Graph Construction
+## Rule Graph Construction
 
-## Overview
+### Overview
 
 Build logic in [Pants](https://www.pantsbuild.org/) is declared using collections of `@rules` with recursively memoized and invalidated results. This framework (known as Pants' "Engine") has similar goals to Bazel's [Skyframe](https://bazel.build/designs/skyframe.html) and the [Salsa](https://github.com/salsa-rs/salsa) framework: users define logic using a particular API, and the framework manages tracking the dependencies between nodes in a runtime graph.
 
@@ -15,11 +15,11 @@ In order to maximize the amount of work that can be reused at runtime, Pants sta
 
 Concepts used in compilers, including live variable analysis and monomorphization, can also be useful in rule graph construction to minimize rule identities and pre-decide which versions of their dependencies they will use.
 
-## Concepts
+### Concepts
 
 A successfully constructed `RuleGraph` contains a graph where nodes have one of three types, `Rule`s, `Query`s, and `Param`s, which map fairly closely to what a Pants `@rule` author consumes. The edges between nodes represent dependencies: `Query`s are always roots of the graph, `Param`s are always leaves, and `Rule`s represent the end user logic making up all of the internal nodes of the graph.
 
-### Rules
+#### Rules
 
 A `Rule` is a function or coroutine with all of its inputs declared as part of its type signature. The end user type signature is made up of:
 
@@ -31,13 +31,13 @@ In the `RuleGraph`, these are encoded in a [Rule](https://github.com/pantsbuild/
 
 `Rule`s never refer to one another by name (i.e., they do not call one another by name): instead, their signature declares their requirements in terms of input/output types, and rule graph construction decides which potential dependencies will provide those requirements.
 
-### Queries
+#### Queries
 
 The roots/entrypoints of a `RuleGraph` are `Query`s, which should correspond one-to-one to external callsites that use the engine to request that values are computed. A `Query` has an output type, and a series of input types: `Query(output_type, (*input_types))`.
 
 If a user makes a request to the engine that does not have a corresponding `Query` declared, the engine fails rather than attempting to dynamically determine which `Rules` to use to answer the `Query`: how a `RuleGraph` is constructed should show why that is the case.
 
-### Params
+#### Params
 
 `Params` are typed, comparable (`eq`/`hash`) values that represent both the inputs to `Rules`, and the building block of the runtime memoization key for a `Rule`. The set of `Params` (unique by type) that are consumed to create a `Rule`'s inputs (plus the `Rule`'s own identity) make up the memoization key for a runtime instance of the `Rule`.
 
@@ -47,7 +47,7 @@ The `Param`s that are available to a `Rule` are made available by the `Rule`'s d
 
 `Params` flow down the graph from `Query`s and the provided `Param`s of `Get`s: their presence does not need to be re-declared at each intermediate callsite. When a `Rule` consumes a `Param` as a positional argument, that `Param` will no longer be available to that `Rule`'s dependencies (but it might still be present in other subgraphs adjacent to that `Rule`).
 
-## Goals
+### Goals
 
 The goals of `RuleGraph` construction are:
 
@@ -61,7 +61,7 @@ If either of the goals were removed, `RuleGraph` construction might be more stra
 
 But both of the goals are important because together they allow for an API that is easy to write `Rule`s for, with minimal boilerplate required to get the inputs needed for a `Rule` to compute a value, and minimal invalidation. Because the identity of a `Rule` is computed from its transitive input `Param`s rather than from its positional arguments, `Rule`s can accept arbitrarily-many large input values (which don't need to implement hash) with no impact on its memoization hit rate.
 
-## Constraints
+### Constraints
 
 There are a few constraints that decide which `Rule`s are able to provide dependencies for one another:
 
@@ -71,7 +71,7 @@ There are a few constraints that decide which `Rule`s are able to provide depend
 - `provided_params` - When deciding whether one `Rule` can use another `Rule` to provide the output type of a `Get`, a constraint is applied that the candidate depedency must (transitively) consume the `Param` that is provided by the `Get`.
   - For example: if a `Rule` `z` has a `Get(A, B)`, only `Rule`s that compute an `A` and (transitively) consume a `B` are eligible to be used. This also means that a `Param` `A` which is already in scope for `Rule` `z` is not eligible to be used, because it would trivially not consume `B`.
 
-## Implementation
+### Implementation
 
 As of [3a188a1e06](https://github.com/pantsbuild/pants/blob/3a188a1e06d8c27ff86d8c311ff1b2bdea0d39ff/src/rust/engine/rule_graph/src/builder.rs#L202-L219), we construct a `RuleGraph` using a combination of data flow analysis and some homegrown (and likely problematic: see the "Issue Overview") node splitting on the call graph of `Rule`s.
 

--- a/versioned_docs/version-2.18/docs/helm/index.mdx
+++ b/versioned_docs/version-2.18/docs/helm/index.mdx
@@ -11,7 +11,7 @@ Pants has good support for the most common operations for managing Helm charts s
 Please share feedback for what you need to use Pants with your Helm charts by either [opening a GitHub issue](https://github.com/pantsbuild/pants/issues/new/choose) or [joining our Slack](/community/getting-help)!
 :::
 
-# Initial setup
+## Initial setup
 
 First, activate the relevant backend in `pants.toml`:
 
@@ -40,7 +40,7 @@ name: bar
 version: 0.1.0
 ```
 
-## Adding `helm_chart` targets
+### Adding `helm_chart` targets
 
 Helm charts are identified by the presence of a `Chart.yaml` or `Chart.yml` file, which contains relevant metadata about the chart like its name, version, dependencies, etc. To get started quickly you can create a simple `Chart.yaml` file in your sources folder:
 
@@ -65,11 +65,11 @@ Created src/helm/example/BUILD:
 
 If your workspace contains any Helm unit tests (under a `tests` folder), Pants will also idenfity them and create `helm_unittest_tests` targets for them. Additionally, if your unit tests also have snapshots (under a `tests/__snapshot__` folder), `tailor` will identify those files as test snapshots and will create `resources` targets for them. See "Snapshot testing" below for more info.
 
-## Basic operations
+### Basic operations
 
 The given setup is enough to now do some common operations on our Helm chart source code.
 
-### Linting
+#### Linting
 
 The Helm backend has an implementation of the Pants' `lint` goal which hooks it with the `helm lint` command:
 
@@ -100,7 +100,7 @@ Likewise, in a similar way you could enable strict linting globally and then cho
 
 You can set the field `skip_lint=True` on each `helm_chart` target to avoid linting it.
 
-### Package
+#### Package
 
 Packing helm charts is supported out of the box via the Pants' `package` goal. The final package will be saved as a `.tgz` file under the `dist` folder at your source root.
 
@@ -113,7 +113,7 @@ Built Helm chart artifact: testprojects.src.helm.example/example/example-0.2.0.t
 
 The final output folder can customised using the `output_path` field in the `helm_chart` target. Run `pants help helm_chart` for more information.
 
-### Helm chart version
+#### Helm chart version
 
 Helm charts are versioned artifacts with the value of the `version` field in `Chart.yaml` determining the actual version of the chart. Pants needs to know the version of a first party chart to be able to build packages and correctly establish the dependencies among them. By default, Pants will use the value in `Chart.yaml` as the given version of a chart but it also supports overriding that value via the `version` field in the `helm_chart` target.
 
@@ -153,7 +153,7 @@ helm_chart(version=env('HELM_CHART_VERSION'))
 
 Now the version value for this chart will be what has been set as the value of the environment variable `HELM_CHART_VERSION`.
 
-# Helm Unit tests
+## Helm Unit tests
 
 The Helm backend supports running Helm unit tests via the [Helm `unittest` plugin](https://github.com/quintush/helm-unittest). To run unit tests follow the instructions on how to use that plugin and then create a `BUILD` file in the same folder where your tests live with the following target:
 
@@ -201,7 +201,7 @@ pants test ::
 ✓ testprojects/src/helm/example/tests/env-configmap_test.yaml succeeded in 0.75s.
 ```
 
-### Feeding additional files to unit tests
+#### Feeding additional files to unit tests
 
 In some cases we may want our tests to have access to additional files which are not part of the chart. This can be achieved by setting a dependency between our unit test targets and a `resources` target as follows:
 
@@ -304,7 +304,7 @@ not affected by the source roots setting. When using `relocated_files`, the file
 to the value set in the `dest` field.
 :::
 
-### Snapshot testing
+#### Snapshot testing
 
 Unit test snapshots are supported by Pants by wrapping the snapshots in resources targets, as shown in the previous section. Snapshot resources will be automatically inferred as dependencies of the tests where they reside, so there is no need to add a explicit `dependencies` relationship in your `helm_unittest_tests` targets.
 
@@ -318,7 +318,7 @@ This will generate test snapshots for tests that require them, with out-of-date 
 
 If new `__snapshot__` folders are created after running the `generate-snapshots` target, we recommend running the `tailor` goal again so that Pants can detect these new folders and create `resources` targets as appropriate.
 
-### Timeouts
+#### Timeouts
 
 Pants can cancel tests that take too long, which is useful to prevent tests from hanging indefinitely.
 
@@ -352,13 +352,13 @@ If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will 
 
 Use the option `pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
-# Publishing Helm charts
+## Publishing Helm charts
 
 Pants only supports publishing Helm charts to OCI registries, a feature that was made generally available in Helm 3.8.
 
 The publishing is done with Pants' `publish` goal but first you will need to tell Pants what are the possible destination registries where to upload your charts.
 
-## Configuring OCI registries
+### Configuring OCI registries
 
 In a similar way as the `docker_image` target, a `helm_chart` target takes an optional `registries` field whose value is a list of registry endpoints (prefixed by the `oci://` protocol):
 
@@ -406,7 +406,7 @@ helm_chart(
 )
 ```
 
-## Setting a repository name
+### Setting a repository name
 
 When publishing charts into an OCI registry, you most likely will be interested on separating them from other kind of OCI assets (i.e. container images). For doing so you can set a `repository` field in the `helm_chart` target so the chart artifact will be uploaded to the given path:
 
@@ -426,7 +426,7 @@ You can also set a default global repository in `pants.toml` as in the following
 default_registry_repository = "charts"
 ```
 
-# Managing Chart Dependencies
+## Managing Chart Dependencies
 
 Helm charts can depend on other charts, whether first-party charts defined in the same repo, or third-party charts published in a registry. Pants uses this dependency information to know when work needs to be re-run.
 
@@ -434,7 +434,7 @@ Helm charts can depend on other charts, whether first-party charts defined in th
 To benefit from Pants dependency management and inference in your Helm charts, you will need to use `apiVersion: v2` in your `Chart.yaml` file.
 :::
 
-## `Chart.yaml` dependencies
+### `Chart.yaml` dependencies
 
 Pants will automatically infer dependencies from the `Chart.yaml` file.
 
@@ -471,7 +471,7 @@ pants dependencies src/helm/bar
 src/helm/foo
 ```
 
-## Explicitly provided dependencies in `BUILD` files
+### Explicitly provided dependencies in `BUILD` files
 
 If you prefer, you can let your BUILD files be the "source of truth" for dependencies, instead of specifying them in `Chart.yaml`:
 
@@ -499,7 +499,7 @@ helm_chart(dependencies=["//src/helm/foo"])
 
 In this case, the `pants dependencies` command will show the same result and, in addition, Pants will modify its copy of `bar`'s `Chart.yaml` before using it, so that it includes `foo` in its dependency list. Note that Pants will not modify the original copy in your source tree, only the copy it uses in the sandboxed execution environment.
 
-## Third party chart artifacts
+### Third party chart artifacts
 
 Third party charts are provided to Pants using the `helm_artifact` target:
 

--- a/versioned_docs/version-2.18/docs/introduction/welcome-to-pants.mdx
+++ b/versioned_docs/version-2.18/docs/introduction/welcome-to-pants.mdx
@@ -5,11 +5,11 @@
 
 ---
 
-# What is Pants?
+## What is Pants?
 
 Pants is a fast, scalable, user-friendly build and developer workflow system for codebases of all sizes, including yours!
 
-# What does Pants do?
+## What does Pants do?
 
 Pants installs, orchestrates and runs dozens of standard underlying tools - compilers, code generators, dependency resolvers, test runners, linters, formatters, packagers, REPLs and more - composing them into a single stable, hermetic toolchain, and speeding up your workflows via caching and concurrency.
 
@@ -17,13 +17,13 @@ Pants is designed to be easy to adopt, use, and extend. It doesn't require you t
 
 Pants is currently focused on Python, Go, Java, Scala, Shell, and Docker, with more languages and frameworks coming soon. [The Pants community](/community/members) is friendly and helpful and welcomes involvement of anyone who is interested in creating modern software development tooling.
 
-# Who is Pants for?
+## Who is Pants for?
 
 Pants is useful for repos of all sizes, but is particularly valuable for those containing multiple distinct but interdependent pieces.
 
 Pants works well with (but does not require) a [_monorepo_ architecture](https://blog.pantsbuild.org/the-monorepo-approach-to-code-management/): a codebase containing multiple projects—often using multiple programming languages and frameworks—in a single unified repository. If you want to scale your codebase without breaking it up into multiple disconnected repos, with all the versioning and maintenance headaches that causes, Pants provides the tooling for you to do so effectively.
 
-# What are the main features of Pants?
+## What are the main features of Pants?
 
 Pants is designed for fast, consistent, ergonomic builds. Some noteworthy features include:
 
@@ -36,7 +36,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 - Extensibility and customizability via a plugin API
 - Code introspection features
 
-# Which languages and frameworks does Pants support?
+## Which languages and frameworks does Pants support?
 
 - Pants [ships](page:language-support) with support for [Python](../python/overview/index.mdx), [Go](../go/index.mdx), [Java](../java-and-scala/index.mdx), [Scala](../java-and-scala/index.mdx) and [Shell](../shell/index.mdx).
 - Pants supports a wide range of code generators (such as Thrift, Protobuf, Scrooge and Avro), linters and formatters, and it is easy to add support for new or custom ones
@@ -45,7 +45,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 We're listening to the community for which languages, frameworks and tools we should support next, so let us know about your needs by [opening an issue](https://github.com/pantsbuild/pants/issues/new/choose) on GitHub or [chatting with us](/community/members) about it on the community Slack!
 Pants was designed for extensibility, and we welcome [contributions](../contributions/index.mdx)!
 
-# How does Pants work?
+## How does Pants work?
 
 The core of Pants is its execution engine, which sequences and coordinates all the underlying work. The engine is written in Rust, for performance. The underlying work is performed by executing _rules_, which are typed Python 3 async coroutines for familiarity and simplicity.
 
@@ -53,17 +53,17 @@ The engine is designed so that fine-grained invalidation, concurrency, hermetici
 
 See [here](./how-does-pants-work.mdx) for more details about the Pants engine.
 
-# Is Pants similar to X?
+## Is Pants similar to X?
 
 Pants (v2) is a leap forward in the evolution of build systems, a category that runs from the venerable Make through Ant, Maven, Gradle and SBT, to Bazel, Please, Buck, Pants v1 and others.
 
 Its design leans on ideas and inspiration from these earlier tools, while optimizing not just for speed and correctness, but also for ease of adoption, ease of use and ease of extension, all for real-world use cases at a variety of teams.
 
-# Who uses Pants?
+## Who uses Pants?
 
 Pants is making engineering teams productive and happy at a range of companies and organizations. See a sample of them [here](page:who-uses-pants)!
 
-# Who develops Pants?
+## Who develops Pants?
 
 Pants is an open-source software project, developed at [github.com/pantsbuild/pants](https://github.com/pantsbuild/pants). Pants is released under the [Apache License 2.0](https://github.com/pantsbuild/pants/blob/master/LICENSE).
 

--- a/versioned_docs/version-2.18/docs/terraform/index.mdx
+++ b/versioned_docs/version-2.18/docs/terraform/index.mdx
@@ -11,7 +11,7 @@ Pants is currently building support for developing and deploying Terraform. Simp
 Please share feedback for what you need to use Pants with your Terraform modules and deployments by either [opening a GitHub issue](https://github.com/pantsbuild/pants/issues/new/choose) or [joining our Slack](/community/getting-help)!
 :::
 
-# Initial setup
+## Initial setup
 
 First, activate the relevant backend in `pants.toml`:
 
@@ -26,14 +26,14 @@ backend_packages = [
 
 The Terraform backend also needs Python to run Pants's analysers. The setting `[python].interpreter_constraints` will need to be set.
 
-## Adding Terraform targets
+### Adding Terraform targets
 
 The Terraform backend has 2 target types:
 
 - `terraform_module` for Terraform source code
 - `terraform_deployment` for deployments that can be deployed with the `experimental-deploy` goal
 
-### Modules
+#### Modules
 
 The `tailor` goal will automatically generate `terraform_module` targets. Run [`pants tailor ::`](../getting-started/initial-configuration.mdx#5-generate-build-files). For example:
 
@@ -43,7 +43,7 @@ Created src/terraform/root/BUILD:
   - Add terraform_module target root
 ```
 
-### Deployments
+#### Deployments
 
 `terraform_deployments` must be manually created. The deployment points to a `terraform_module` target as its `root_module` field. This module will be the "root" module that Terraform operations will be run on. You can reference vars files with the `var_files` field. You can have multiple deployments reference the same module:
 
@@ -53,7 +53,7 @@ terraform_deployment(name="prod", root_module=":root", var_files=["prod.tfvars"]
 terraform_deployment(name="test", root_module=":root", var_files=["test.tfvars"])
 ```
 
-### Lockfiles
+#### Lockfiles
 
 Automatic lockfile management is currently in progress. You can include lockfiles manually as a dependency:
 
@@ -62,9 +62,9 @@ terraform_deployment(name="prod", root_module=":root", dependencies=[":lockfile"
 file(name="lockfile", source=".terraform.lock.hcl")
 ```
 
-## Basic Operations
+### Basic Operations
 
-### Formatting
+#### Formatting
 
 Run `terraform fmt` as part of the `fix`, `fmt`, or `lint` goals.
 
@@ -75,7 +75,7 @@ pants fix ::
 ✓ terraform-fmt made no changes.
 ```
 
-### Validate
+#### Validate
 
 Run `terraform validate` as part of the `check` goal.
 
@@ -94,7 +94,7 @@ Success! The configuration is valid.
 terraform_module(skip_terraform_validate=True)
 ```
 
-### Deploying
+#### Deploying
 
 :::caution Terraform deployment support is in alpha stage
 Many options and features aren't supported yet.

--- a/versioned_docs/version-2.18/docs/using-pants/environments.mdx
+++ b/versioned_docs/version-2.18/docs/using-pants/environments.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Environments
+## Environments
 
 :::caution Environments are currently in `preview`, and have not yet stabilized.
 We'd love your feedback on how Environments could be most useful to you! Please refer to [the tracking issue](https://github.com/pantsbuild/pants/issues/17355) for known stabilization blockers.
@@ -17,7 +17,7 @@ By default, Pants will execute all sandboxed build work directly on localhost. B
 2. remotely via [remote execution](./remote-caching-&-execution/remote-execution.mdx)
 3. locally, but with a non-default set of environment variables and settings (such as when different platforms need different values, or when cross-building)
 
-## Defining environments
+### Defining environments
 
 Environments are defined using environment targets:
 
@@ -53,7 +53,7 @@ docker_environment(
 Environment targets are loaded before regular targets in a bootstrap phase, during which macros are unavailable. As such any required field values must be fully defined in the BUILD file without referencing any macros. For optional fields, the use of macros are still discouraged as it may or may not work and Pants makes no guarantees that it will not break in a future version if it were to currently work.
 :::
 
-### Environment-aware options
+#### Environment-aware options
 
 Environment targets have fields ([target](./key-concepts/targets-and-build-files.mdx) arguments) which correspond to [options](./key-concepts/options.mdx) which are marked "environment-aware". When an option is environment-aware, the value of the option that will be used in an environment can be overridden by setting the corresponding field value on the associated environment target. If an environment target does not set a value, it defaults to the value which is set globally via options values.
 
@@ -63,7 +63,7 @@ For example, the [`[python-bootstrap].search_path` option](../../reference/subsy
 Environments are a new concept: if you see an option value which should be marked environment-aware but isn't, please definitely [file an issue](https://github.com/pantsbuild/pants/issues/new/choose)!
 :::
 
-## Consuming environments
+### Consuming environments
 
 To declare which environment they should build with, many target types (but particularly "root" targets like tests or binaries) have an `environment=` field: for example, [`python_tests(environment=..)`](../../reference/targets/python_tests.mdx#environment).
 
@@ -78,7 +78,7 @@ Currently, there is no static validation that a target's environment is compatib
 As we gain more experience with how environments are used in the wild, it's possible that more static validation can be added: your feedback would be very welcome!
 :::
 
-### Setting the environment on many targets at once
+#### Setting the environment on many targets at once
 
 To use an environment everywhere in your repository (or only within a particular subdirectory, or with a particular target
 type), you can use the [`__defaults__` builtin](./key-concepts/targets-and-build-files.mdx#field-default-values). For example, to use an environment named `my_default_environment` globally by default, you would add the following to a `BUILD` file at the root of the repository:
@@ -89,7 +89,7 @@ __defaults__(all=dict(environment="my_default_environment"))
 
 ... and individual targets could override the default as needed.
 
-### Building one target in multiple environments
+#### Building one target in multiple environments
 
 If a target will always need to be built in multiple environments (rather than conditionally based on which user is building it: see the "Toggle use of an environment for some consumers" section), then you can use the [`parametrize` builtin](./key-concepts/targets-and-build-files.mdx#parametrizing-targets) for the `environment=` field. If you had two environments named `linux` and `macos`, that would look like:
 
@@ -100,7 +100,7 @@ pex_binary(
 )
 ```
 
-### Environment matching
+#### Environment matching
 
 A single environment name may end up referring to different environment targets on different physical machines, or with different global settings applied: this is known as environment "matching".
 
@@ -133,9 +133,9 @@ docker_environment(
 
 In future versions, environment targets will gain additional predicates to control whether they match (for example: `local_environment` will likely gain a predicate that looks for the [presence or value of an environment variable](https://github.com/pantsbuild/pants/issues/17107). But in the meantime, it's possible to override which environments are matched for particular use cases by overriding their configured names: see the "Toggle use of an environment" workflow below for an example.
 
-## Example workflows
+### Example workflows
 
-### Enabling remote execution globally
+#### Enabling remote execution globally
 
 `remote_environment` targets match unless the [`--remote-execution`](../../reference/global-options.mdx#remote_execution) option is disabled. So to cause a particular environment name to use remote execution whenever it is enabled, you could define environment targets which try remote execution first, and then fall back to local execution:
 
@@ -167,7 +167,7 @@ local = "//:local"
 The `2.15.x` series of Pants does not yet support ["speculating" remote execution](https://github.com/pantsbuild/pants/issues/8353) by racing it against another environment (usually local or docker). While we expect that this will be necessary to make remote execution a viable option for local execution on user's laptops (where network connections are less reliable), it is less critical for CI use-cases.
 :::
 
-### Use a `docker_environment` to build the inputs to a `docker_image`
+#### Use a `docker_environment` to build the inputs to a `docker_image`
 
 To build a `docker_image` target containing a `pex_binary` which uses native (i.e. compiled) dependencies on a `macOS` machine, you can configure the `pex_binary` to be built in a `docker_environment`.
 
@@ -206,7 +206,7 @@ Note that the Docker image used in your `docker_environment` does not need to ma
 This means that your `docker_environment` can include things like compilers or other tools relevant to your build, without needing to manually use multi-stage Docker builds.
 :::
 
-### Toggle use of an environment for some consumers
+#### Toggle use of an environment for some consumers
 
 As mentioned above in "Environment matching", environment targets "match" based on their field values and global options. But if two environment targets would be ambiguous in some cases, or if you'd otherwise like to control what a particular environment name means (in CI, for example), you can override an environment name via options.
 

--- a/versioned_docs/version-2.18/docs/using-pants/key-concepts/goals.mdx
+++ b/versioned_docs/version-2.18/docs/using-pants/key-concepts/goals.mdx
@@ -17,7 +17,7 @@ To see the current list of goals, run:
 
 You'll see more goals activated as you activate more [backends](./backends.mdx).
 
-# Running goals
+## Running goals
 
 For example:
 
@@ -48,7 +48,7 @@ Finally, Pants supports running goals in a `--loop`. In this mode, all goals spe
 
 Use `Ctrl+C` to exit the `--loop`.
 
-# Goal arguments
+## Goal arguments
 
 Most goals require arguments to know what to work on.
 
@@ -75,7 +75,7 @@ This will become the default in Pants 2.14.
 See [Advanced target selection](../advanced-target-selection.mdx) for alternative techniques to specify which files/targets to run on.
 :::
 
-## Goal options
+### Goal options
 
 Many goals also have [options](./options.mdx) to change how they behave. Every option in Pants can be set via an environment variable, config file, and the command line.
 

--- a/versioned_docs/version-2.18/docs/using-pants/key-concepts/options.mdx
+++ b/versioned_docs/version-2.18/docs/using-pants/key-concepts/options.mdx
@@ -7,7 +7,7 @@ A deep dive into how options may be configured.
 
 ---
 
-# Option scopes
+## Option scopes
 
 Options are partitioned into named _scopes_.
 
@@ -15,7 +15,7 @@ Some systemwide options belong in the _global scope_. For example, the `--level`
 
 Other options belong to a _subsystem scope_. A _subsystem_ is simply a collection of related options, in a scope. For example, the `pytest` subsystem contains options related to [Python's test framework pytest](../../../reference/subsystems/pytest.mdx).
 
-# Setting options
+## Setting options
 
 Every option can be set in the following ways, in order of precedence:
 
@@ -27,7 +27,7 @@ If an option isn't set in one of these ways, it will take on a default value.
 
 You can inspect both the current value and the default value by using `pants help $scope` or `pants help-advanced $scope`, e.g. `pants help global`.
 
-## Command-line flags
+### Command-line flags
 
 Global options are set using an unqualified flag:
 
@@ -41,7 +41,7 @@ Subsystem options are set by providing the flag, with the name prefixed with the
 pants --source-root-patterns="['^ext']"
 ```
 
-## Environment variables
+### Environment variables
 
 Global options are set using the environment variable `PANTS_{OPTION_NAME}`:
 
@@ -58,7 +58,7 @@ PANTS_SOURCE_ROOT_PATTERNS="['^ext']" pants ...
 
 Note that the scope and option name are upper-cased, and any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `MULTIWORD_NAME`.
 
-## Config file entries
+### Config file entries
 
 Global options are set in the `GLOBAL` section of the config file:
 
@@ -76,7 +76,7 @@ root_patterns = ["/src/python"]
 
 Note that any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `multiword_name`.
 
-### Config file interpolation
+#### Config file interpolation
 
 Environment variables can be interpolated by using the syntax `%(env.ENV_VAR)s`, e.g.:
 
@@ -95,7 +95,7 @@ Additionally, a few special values are pre-populated with the `%(var)s` syntax:
 - `%(pants_distdir)s`: absolute path of the global option `--pants-distdir`, which defaults
   to `{buildroot}/dist/`
 
-# Option types
+## Option types
 
 Every option has a type, and any values you set must be of that type.
 
@@ -109,25 +109,25 @@ The option types are:
 
 A list-valued option may also declare a specific type for its members (e.g., a list of strings, or a list of integers).
 
-## String and integer values
+### String and integer values
 
 Standalone string and integer values are written without quotes. Any quotes will be considered part of the value, after shell escaping.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-intopt=42
 pants --scope-stropt=qux
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_INTOPT=42
 PANTS_SCOPE_STROPT=qux
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -135,11 +135,11 @@ intopt = 42
 stropt = "qux"
 ```
 
-## Boolean values
+### Boolean values
 
 Boolean values can be specified using the special strings `true` and `false`. When specifying them via command-line flags you can also use the `--boolopt/--no-boolopt` syntax.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-boolopt=true
@@ -147,24 +147,24 @@ pants --scope-boolopt
 pants --no-scope-boolopt
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_BOOLOPT=true
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
 boolopt = true
 ```
 
-## List values
+### List values
 
 List values are parsed as Python list literals, so you must quote string values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-listopt="['foo','bar']"
@@ -178,7 +178,7 @@ pants --scope-listopt=foo --scope-listopt=bar
 
 Appending will add to any values from lower-precedence sources, such as config files (`pants.toml`) and possibly Pants's `default`. Otherwise, using `[]` will override any lower-precedence sources.
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_LISTOPT="['foo','bar']"
@@ -190,7 +190,7 @@ Like with command-line flags, you can leave off the `[]` to _append_ elements:
 PANTS_SCOPE_LISTOPT=foo
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -200,7 +200,7 @@ listopt = [
 ]
 ```
 
-### Add/remove semantics
+#### Add/remove semantics
 
 List values have some extra semantics:
 
@@ -250,23 +250,23 @@ listopt.remove = [3, 4]
 But note that this only works in Pants's `.toml` config files, not in environment variables or command-line flags.
 :::
 
-## Dict values
+### Dict values
 
 Dict values are parsed as Python dict literals on the command-line and environment variables, so you must quote string keys and values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-dictopt="{'foo':1,'bar':2}"
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_DICTOPT="{'foo':1,'bar':2}"
 ```
 
-### Config file entries:
+#### Config file entries:
 
 You can use TOML's [nested table features](https://toml.io/en/v1.0.0#inline-table). These are equivalent:
 
@@ -291,7 +291,7 @@ dictopt = """{
 }"""
 ```
 
-### Add/replace semantics
+#### Add/replace semantics
 
 - A value can be preceded by `+`, which will _update_ the value obtained from lower-precedence sources with the entries.
 - Otherwise, the value _replaces_ the one obtained from lower-precendence sources.
@@ -310,7 +310,7 @@ pants --scope-dictopt="{'foo':42,'baz':3}"
 
 will set the value to `{'foo': 42, 'baz': 3}`.
 
-# Reading individual option values from files
+## Reading individual option values from files
 
 If an option value is too large or elaborate to use directly, or if you don't want to hard-code
 values directly in `pants.toml`, you can set the value of any option to the string
@@ -345,7 +345,7 @@ do so by `kill`ing it (after using `ps -ef | grep pantsd` to find its pid), or b
 Pants once with `--no-pantsd`.
 :::
 
-# `.pants.rc` file
+## `.pants.rc` file
 
 You can set up personal Pants config files, using the same TOML syntax as `pants.toml`. By default, Pants looks for the paths `/etc/pantsrc`, `~/.pants.rc`, and `.pants.rc` in the repository root.
 

--- a/versioned_docs/version-2.18/docs/using-pants/key-concepts/source-roots.mdx
+++ b/versioned_docs/version-2.18/docs/using-pants/key-concepts/source-roots.mdx
@@ -13,7 +13,7 @@ Go does have a notion of source roots: where your `go.mod` is located. However, 
 Shell does not have any notion of source roots.
 :::
 
-# What are source roots?
+## What are source roots?
 
 Some project layouts use top-level folders for namespace purposes, but have the code live underneath. However, the code's imports will ignore these top-level folders, thanks to mechanisms like the `$PYTHONPATH` and the JVM classpath. _Source roots_ are a generic equivalent of these concepts.
 
@@ -44,7 +44,7 @@ pkgutil.get_data("project.config", "prod.json")
 
 In the example above, `src/python` is a source root. So, when some code says `from project.app import App`, Pants can know that this corresponds to the code in `src/python/project/app.py`.
 
-# Configuring source roots
+## Configuring source roots
 
 There are two ways to configure source roots:
 
@@ -60,7 +60,7 @@ src/python
 src/rust
 ```
 
-## Configuring source roots using patterns
+### Configuring source roots using patterns
 
 You can provide a set of patterns that match your source roots:
 
@@ -85,7 +85,7 @@ You can use `*` as a glob. For example, `root_patterns = ["/src/*"]` would consi
 - `src/java`
 - `src/assets`
 
-### Configuring no source roots
+#### Configuring no source roots
 
 Many projects do not have any top-level folders used for namespacing.
 
@@ -125,7 +125,7 @@ The default value of the `root_patterns` config key is `["/", "src", "src/python
 These capture a range of common cases, including a source root at the root of the repository. If your source roots match these patterns, you don't need to explicitly configure them.
 :::
 
-## Configuring source roots using marker files
+### Configuring source roots using marker files
 
 You can also denote your source roots using specially-named marker files. To do so, first pick a name (or multiple names) to use:
 
@@ -182,15 +182,15 @@ import server.server.app
 from utils.utils.strutil import capitalize
 ```
 
-# Examples
+## Examples
 
 These project structures are all valid; Pants does not expect you to reorganize your codebase to use the tool.
 
-## `src/<lang>` setup
+### `src/<lang>` setup
 
 This setup is common in "polyglot" repositories: i.e. repos with multiple languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -228,7 +228,7 @@ This setup is common in "polyglot" repositories: i.e. repos with multiple langua
 
 While we have tests in a separate source root here, it's also valid to have tests colocated with their src files.
 
-### Example imports:
+#### Example imports:
 
 ```python
 # Python
@@ -242,7 +242,7 @@ import org.pantsbuild.project.App
 import org.pantsbuild.project.util.Math
 ```
 
-### Config:
+#### Config:
 
 ```toml title="pants.toml"
 [source]
@@ -255,9 +255,9 @@ root_patterns = [
 
 Note that we organized our 3rdparty requirements in the top-level folders `3rdparty/python` and `3rdparty/java`, but we do not need to include them as source roots because we do not have any first-party code there.
 
-## Multiple top-level projects
+### Multiple top-level projects
 
-### Project:
+#### Project:
 
 This layout has lots of nesting; this is only one possible way to organize the repository.
 
@@ -289,7 +289,7 @@ This layout has lots of nesting; this is only one possible way to organize the r
         └── spa.js
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 import ads.billing.calculate_bill
@@ -299,7 +299,7 @@ from base.util.math import add_two
 
 Note that even though the projects live in different top-level folders, you are still able to import from other projects. If you would like to limit this, you can use `pants dependents` or `pants dependencies` in CI to track where imports are being used. See [Project introspection](../project-introspection.mdx).
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 
@@ -320,11 +320,11 @@ root_patterns = [
 ]
 ```
 
-## No source root
+### No source root
 
 Warning: while this project structure is valid, it often does not scale as well as your codebase grows, such as adding new languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -340,7 +340,7 @@ Warning: while this project structure is valid, it often does not scale as well 
 └── pyproject.toml
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 from project.app import App
@@ -349,7 +349,7 @@ from project.util.math import add_two
 pkgutil.get_data("project.config", "prod.json")
 ```
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 

--- a/versioned_docs/version-2.18/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/versioned_docs/version-2.18/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -23,7 +23,7 @@ To reduce boilerplate, some targets also generate other targets:
 - `shell_sources` -> `shell_source`
 - `go_mod` -> `go_third_party_package`
 
-# BUILD files
+## BUILD files
 
 Targets are defined in files with the name `BUILD`. For example:
 
@@ -45,7 +45,7 @@ All target types have a `name` field, which is used to identify the target. Targ
 
 You can autoformat `BUILD` files by enabling a `BUILD` file formatter by adding it to `[GLOBAL].backend_packages` in `pants.toml` (such as `pants.backend.build_files.fmt.black` [or others](./backends.mdx)). Then to format, run `pants fmt '**/BUILD'` or `pants fmt ::` (formats everything).
 
-## Environment variables
+### Environment variables
 
 BUILD files are very hermetic in nature with no support for using `import` or other I/O operations. In order to have dynamic data in BUILD files, you may inject values from the local environment using the `env()` function. It takes the variable name and optional default value as arguments.
 
@@ -60,7 +60,7 @@ python_distribution(
 )
 ```
 
-# Target addresses
+## Target addresses
 
 A target is identified by its unique address, in the form `path/to/dir:name`. The above example has the addresses `helloworld/greet:tests` and `helloworld/greet:bin`.
 
@@ -83,7 +83,7 @@ You can refer to this target with either `helloworld/greet:greet` or the abbrevi
 Addresses defined in the `BUILD` file at the root of your repository are prefixed with `//`, e.g. `//:my_tgt`.
 :::
 
-# `source` and `sources` field
+## `source` and `sources` field
 
 Targets like `python_test` and `resource` have a `source: str` field, while target generators like `python_tests` and `resources` have a `sources: list[str]` field. This determines which source files belong to the target.
 
@@ -123,7 +123,7 @@ Including the same file in the `source` / `sources` field for multiple targets c
 You can run `pants list path/to/file.ext` to see all "owning" targets to check if >1 target has the file in its `source` field.
 :::
 
-# `dependencies` field
+## `dependencies` field
 
 A target's dependencies determines which other first-party code and third-party requirements to include when building the target.
 
@@ -166,7 +166,7 @@ You can use the prefix `!!` to transitively exclude a dependency, meaning that e
 Transitive excludes can only be used in target types that conventionally are not depended upon by other targets, such as `pex_binary`, `python_distribution`, and `python_test` / `python_tests`. This is meant to limit confusion, as using `!!` in something like a `python_source` / `python_sources` target could result in surprising behavior for everything that depends on it. (Pants will print a helpful error when using `!!` when it's not legal.)
 :::
 
-# Field default values
+## Field default values
 
 As mentioned above in [BUILD files](./targets-and-build-files.mdx#build-files), most target fields have sensible defaults. And it's easy to override those values on a specific target. But applying the same non-default value on many targets can get unwieldy, error-prone and hard to maintain. Enter `__defaults__`.
 
@@ -215,7 +215,7 @@ To reset any modified defaults, simply override with the empty dict:
     __defaults__(all={})
 ```
 
-## Supporting optional plugin fields
+### Supporting optional plugin fields
 
 Normally Pants presents an error message when attempting to provide a default value for a field that doesn't exist for the target. However, some fields comes from plugins, and to support disabling a plugin without having to remove any default values referencing any plugin fields it was providing, there is a `ignore_unknown_fields` option to use:
 
@@ -228,7 +228,7 @@ Normally Pants presents an error message when attempting to provide a default va
     )
 ```
 
-## Extending field defaults
+### Extending field defaults
 
 To add to a default value rather than replacing it, the current default value for a target field is available in the BUILD file using `<target>.<field>.default`. This allows you to augment a field's default value with much more precision. As an example, if you want to make the default sources for a `python_sources` target to work recursively you may specify a target augmenting the default sources field:
 
@@ -242,7 +242,7 @@ python_sources(
 )
 ```
 
-# Target generation
+## Target generation
 
 To reduce boilerplate, Pants provides target types that generate other targets. For example:
 
@@ -320,7 +320,7 @@ It's useful for metadata to be as fine-grained as feasible, such as by using the
 [`pants tailor ::`](../../getting-started/initial-configuration.mdx#5-generate-build-files) will automatically create targets that only apply metadata for the directory.
 :::
 
-# Parametrizing targets
+## Parametrizing targets
 
 It can be useful to create multiple targets describing the same entity, each with different metadata. For example:
 

--- a/versioned_docs/version-2.18/docs/using-pants/remote-caching-&-execution/index.mdx
+++ b/versioned_docs/version-2.18/docs/using-pants/remote-caching-&-execution/index.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Overview
+## Overview
 
 By default, Pants executes processes in a local [environment](../environments.mdx) on the system on which it is run, and caches the results of those processes locally as well. Besides this "local execution" mode of operation, Pants also supports two distributed modes of operation:
 
@@ -15,7 +15,7 @@ By default, Pants executes processes in a local [environment](../environments.md
 
 Pants does this by using the "Remote Execution API" to converse with the remote cache or remote execution server.
 
-## What is Remote Execution API?
+### What is Remote Execution API?
 
 Pants is compatible with remote caching and remote execution servers that comply with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI protocol is supported by several different server and client projects including Bazel and of course Pants.
 
@@ -31,7 +31,7 @@ Pants calls the CAS a "store server" and the execution service an "execution ser
 
 The REAPI model contains the notion of an "instance." An "instance" is a distinct deployment of a CAS and/or execution service that is given a specific name. All REAPI operations send an instance name to the server, thus a single network endpoint can conceivably support multiple REAPI deployments.
 
-# Server compatibility
+## Server compatibility
 
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
@@ -53,6 +53,6 @@ Bazel Remote Cache supports local disk, S3, GCS, and Azure Blob storage options 
 
 There are a few [other](https://github.com/bazelbuild/remote-apis) systems and services in this space, but they have not, to our knowledge, been tested with Pants. Let us know if you have any experience with them!
 
-# Resources
+## Resources
 
 - The [remote-apis-testing project](https://gitlab.com/remote-apis-testing/remote-apis-testing) maintains a compatibility test suite of the various server and client implementations of REAPI.

--- a/versioned_docs/version-2.18/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
+++ b/versioned_docs/version-2.18/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
@@ -5,17 +5,17 @@
 
 ---
 
-# What is remote caching?
+## What is remote caching?
 
 Remote caching allows Pants to store and retrieve the results of process execution to and from a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"), rather than only using your machine's local Pants cache. This allows Pants to share a cache across different runs and different machines, for example, all of your CI workers sharing the same fine-grained cache.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote caching requires the availability of a REAPI-compatible cache. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants Configuration
+### Pants Configuration
 
 After you have either set up a REAPI cache server or obtained access to one, the next step is to point Pants to it so that Pants will use it to read and write process results.
 
@@ -31,6 +31,6 @@ remote_instance_name = "main"
 
 If the endpoint is using TLS, then the `remote_store_address` option would be specified with the `grpcs://` scheme, i.e. `"grpcs://cache.corp.example.com:8980"`.
 
-# Reference
+## Reference
 
 Run `pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.

--- a/versioned_docs/version-2.18/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
+++ b/versioned_docs/version-2.18/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
@@ -9,17 +9,17 @@
 Remote execution support in Pants comes with several limitations. For example, Pants requires that the server's operating system match the client's operating system. In practice, this means that Pants must be running on Linux because all three major server projects generally only operate on Linux.
 :::
 
-# What is remote execution?
+## What is remote execution?
 
 "Remote execution" allows Pants to offload execution of processes to a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI standard is supported by several different server and client projects including Bazel and of course Pants.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote execution requires the availability of a REAPI-compatible execution server. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants
+### Pants
 
 After you have either set up a REAPI server or obtained access to one, the next step is to point Pants to it so that Pants may submit REAPI execution requests. The server should be running a CAS and execution service. These may be the same network endpoint, but for Pants' purposes, they are configured by different configuration options.
 
@@ -33,7 +33,7 @@ remote_execution_address = "grpc://build.corp.example.com:8980"
 remote_instance_name = "main"
 ```
 
-### Environment-specific settings
+#### Environment-specific settings
 
 The REAPI execution service selects a worker for a process by consulting the "platform properties" that are passed in a remote execution request. These platform properties are key/value pairs that are configured for particular workers in the server. Generally, you will configure these in the server (or be provided them by your server's administrator), and then configure Pants to match particular workers using their relevant platform properties.
 
@@ -52,7 +52,7 @@ remote_environment(
 
 Your `remote_environment` will also need to override any [environment-aware options](../environments.mdx) which configure the relevant tools used in your repository. For example: if building Python code, a Python interpreter must be available and matched via the environment-aware options of `[python-bootstrap]`. If using protobuf support, then you may also need `unzip` available in the remote execution environment in order to unpack the protoc archive. Etc.
 
-### Concurrency
+#### Concurrency
 
 Finally, you should configure Pants to limit the number of concurrent execution requests that are sent to the REAPI server. The `process_execution_remote_parallelism` option controls this concurrency. For example, if `process_execution_remote_parallelism` is set to `20`, then Pants will only send a maximum of 20 execution requests at a single moment of time.
 
@@ -72,7 +72,7 @@ remote_execution_extra_platform_properties = [
 process_execution_remote_parallelism = 20
 ```
 
-### TLS
+#### TLS
 
 You can enable TLS by prefixing the `remote_store_address` and `remote_execution_address` with `grpcs://` instead of `grpc://`.
 
@@ -93,7 +93,7 @@ remote_client_certs_path = "/etc/ssl/certs/client-cert.pem"
 remote_client_key_path = "/etc/ssl/certs/client-key.pem"
 ```
 
-# Reference
+## Reference
 
 For global options, run `pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.
 

--- a/versioned_docs/version-2.18/docs/using-pants/validating-dependencies.mdx
+++ b/versioned_docs/version-2.18/docs/using-pants/validating-dependencies.mdx
@@ -76,7 +76,7 @@ backend_packages.add = [
 This does not mean you should not use it, only that it is in "preview" mode meaning that things may change between releases without following our deprecation policy as we work on stabilizing this feature. See [the stabilization ticket](https://github.com/pantsbuild/pants/issues/17634) for what remains to be done for the visibility backend to graduate out of preview.
 :::
 
-# Dependencies and dependents
+## Dependencies and dependents
 
 The visibility rules operates on the dependency link between two targets. Dependencies are directional, so if target `A` depends on another target `B` the dependency goes from the "origin" target `A` -> `B`, we say that `B` is the **dependency** of `A`, while `A` is the **dependent** of `B`.
 
@@ -180,7 +180,7 @@ If your codebase has a very complex dependency graph, you may need to make sure 
 
 In this scenario, you may need to look into alternative solutions to codify these constraints. For example, to check for violations, you could query the dependencies of component `C1` (transitively) using the `dependencies` goal with the `--transitive` option to confirm none of the modules from component `C3` are listed. If there are some, you may find the `paths` goal helpful as it would show you exactly why a certain module from component `C1` depends on a given module in component `C3` if it is unclear.
 
-## Rule sets
+### Rule sets
 
 As there may be many targets and files with dependencies, odds are that they won't all share the same set of rules. The rules keywords accepts multiple sets of rules, or "rule sets", along with "selector rules" that is used to select which set to use for each target.
 
@@ -289,7 +289,7 @@ The previous example, using this alternative syntax for the selectors, would loo
   )
 ```
 
-## Glob syntax
+### Glob syntax
 
 The visibility rules are all about matching globs. There are two wildcards: the `*` matches anything except `/`, and the `**` matches anything including `/`. (For paths that is non-recursive and recursive globbing respectively.)
 
@@ -319,7 +319,7 @@ some/directory/*
 
 So far the rule globs have been matched from anywhere in the matched to path up to the end. To ensure the path begins with a certain pattern we'd have to provide full paths in our rules, like `src/python/proj/lib/file.py` if we want to make sure that our `file.py` is from the `src/` tree. To avoid lengthy and rigid rule globs hurting refactorings etc, there's a concept of "anchoring" the rule. That will apply the rule glob from a fixed point in the matched to path, and there are three such points: project root, rule declaration path and rule invocation path. The difference between declaration and invocation is explained below.
 
-#### Anchoring mode for path globs
+##### Anchoring mode for path globs
 
 The glob prefix specifies which "anchoring mode" to use, and are:
 
@@ -340,7 +340,7 @@ The glob prefix specifies which "anchoring mode" to use, and are:
 
 > 🚧 Regardless of anchoring mode, all rules are always anchored to the end of the matched path.
 
-#### Targeting non-source files
+##### Targeting non-source files
 
 So far most examples have been about providing rules that match source files. This will likely be the most common scenario, but other targets may just as well need to be considered. For the general case, non-source file targets will be matched using the directory where it has been declared (the path containing the BUILD file in most cases).
 
@@ -391,7 +391,7 @@ __dependencies_rules__(
 )
 ```
 
-## Rule actions
+### Rule actions
 
 When a matching rule is found for a path, the path is either allowed or denied based on the rule's action. The dependency link as a whole is only allowed if both ends of the dependency allow it. By default a rule's action is `ALLOW`, but may be changed to `DENY` or `WARN`. The `WARN` action logs a warning message rather than raising an error, but will otherwise allow the dependency.
 

--- a/versioned_docs/version-2.19/docs/contributions/development/internal-architecture.mdx
+++ b/versioned_docs/version-2.19/docs/contributions/development/internal-architecture.mdx
@@ -5,9 +5,9 @@
 
 ---
 
-# Rule Graph Construction
+## Rule Graph Construction
 
-## Overview
+### Overview
 
 Build logic in [Pants](https://www.pantsbuild.org/) is declared using collections of `@rules` with recursively memoized and invalidated results. This framework (known as Pants' "Engine") has similar goals to Bazel's [Skyframe](https://bazel.build/designs/skyframe.html) and the [Salsa](https://github.com/salsa-rs/salsa) framework: users define logic using a particular API, and the framework manages tracking the dependencies between nodes in a runtime graph.
 
@@ -15,11 +15,11 @@ In order to maximize the amount of work that can be reused at runtime, Pants sta
 
 Concepts used in compilers, including live variable analysis and monomorphization, can also be useful in rule graph construction to minimize rule identities and pre-decide which versions of their dependencies they will use.
 
-## Concepts
+### Concepts
 
 A successfully constructed `RuleGraph` contains a graph where nodes have one of three types, `Rule`s, `Query`s, and `Param`s, which map fairly closely to what a Pants `@rule` author consumes. The edges between nodes represent dependencies: `Query`s are always roots of the graph, `Param`s are always leaves, and `Rule`s represent the end user logic making up all of the internal nodes of the graph.
 
-### Rules
+#### Rules
 
 A `Rule` is a function or coroutine with all of its inputs declared as part of its type signature. The end user type signature is made up of:
 
@@ -31,13 +31,13 @@ In the `RuleGraph`, these are encoded in a [Rule](https://github.com/pantsbuild/
 
 `Rule`s never refer to one another by name (i.e., they do not call one another by name): instead, their signature declares their requirements in terms of input/output types, and rule graph construction decides which potential dependencies will provide those requirements.
 
-### Queries
+#### Queries
 
 The roots/entrypoints of a `RuleGraph` are `Query`s, which should correspond one-to-one to external callsites that use the engine to request that values are computed. A `Query` has an output type, and a series of input types: `Query(output_type, (*input_types))`.
 
 If a user makes a request to the engine that does not have a corresponding `Query` declared, the engine fails rather than attempting to dynamically determine which `Rules` to use to answer the `Query`: how a `RuleGraph` is constructed should show why that is the case.
 
-### Params
+#### Params
 
 `Params` are typed, comparable (`eq`/`hash`) values that represent both the inputs to `Rules`, and the building block of the runtime memoization key for a `Rule`. The set of `Params` (unique by type) that are consumed to create a `Rule`'s inputs (plus the `Rule`'s own identity) make up the memoization key for a runtime instance of the `Rule`.
 
@@ -47,7 +47,7 @@ The `Param`s that are available to a `Rule` are made available by the `Rule`'s d
 
 `Params` flow down the graph from `Query`s and the provided `Param`s of `Get`s: their presence does not need to be re-declared at each intermediate callsite. When a `Rule` consumes a `Param` as a positional argument, that `Param` will no longer be available to that `Rule`'s dependencies (but it might still be present in other subgraphs adjacent to that `Rule`).
 
-## Goals
+### Goals
 
 The goals of `RuleGraph` construction are:
 
@@ -61,7 +61,7 @@ If either of the goals were removed, `RuleGraph` construction might be more stra
 
 But both of the goals are important because together they allow for an API that is easy to write `Rule`s for, with minimal boilerplate required to get the inputs needed for a `Rule` to compute a value, and minimal invalidation. Because the identity of a `Rule` is computed from its transitive input `Param`s rather than from its positional arguments, `Rule`s can accept arbitrarily-many large input values (which don't need to implement hash) with no impact on its memoization hit rate.
 
-## Constraints
+### Constraints
 
 There are a few constraints that decide which `Rule`s are able to provide dependencies for one another:
 
@@ -71,7 +71,7 @@ There are a few constraints that decide which `Rule`s are able to provide depend
 - `provided_params` - When deciding whether one `Rule` can use another `Rule` to provide the output type of a `Get`, a constraint is applied that the candidate depedency must (transitively) consume the `Param` that is provided by the `Get`.
   - For example: if a `Rule` `z` has a `Get(A, B)`, only `Rule`s that compute an `A` and (transitively) consume a `B` are eligible to be used. This also means that a `Param` `A` which is already in scope for `Rule` `z` is not eligible to be used, because it would trivially not consume `B`.
 
-## Implementation
+### Implementation
 
 As of [3a188a1e06](https://github.com/pantsbuild/pants/blob/3a188a1e06d8c27ff86d8c311ff1b2bdea0d39ff/src/rust/engine/rule_graph/src/builder.rs#L202-L219), we construct a `RuleGraph` using a combination of data flow analysis and some homegrown (and likely problematic: see the "Issue Overview") node splitting on the call graph of `Rule`s.
 

--- a/versioned_docs/version-2.19/docs/helm/index.mdx
+++ b/versioned_docs/version-2.19/docs/helm/index.mdx
@@ -11,7 +11,7 @@ Pants has good support for the most common operations for managing Helm charts s
 Please share feedback for what you need to use Pants with your Helm charts by either [opening a GitHub issue](https://github.com/pantsbuild/pants/issues/new/choose) or [joining our Slack](/community/getting-help)!
 :::
 
-# Initial setup
+## Initial setup
 
 First, activate the relevant backend in `pants.toml`:
 
@@ -40,7 +40,7 @@ name: bar
 version: 0.1.0
 ```
 
-## Adding `helm_chart` targets
+### Adding `helm_chart` targets
 
 Helm charts are identified by the presence of a `Chart.yaml` or `Chart.yml` file, which contains relevant metadata about the chart like its name, version, dependencies, etc. To get started quickly you can create a simple `Chart.yaml` file in your sources folder:
 
@@ -65,11 +65,11 @@ Created src/helm/example/BUILD:
 
 If your workspace contains any Helm unit tests (under a `tests` folder), Pants will also idenfity them and create `helm_unittest_tests` targets for them. Additionally, if your unit tests also have snapshots (under a `tests/__snapshot__` folder), `tailor` will identify those files as test snapshots and will create `resources` targets for them. See "Snapshot testing" below for more info.
 
-## Basic operations
+### Basic operations
 
 The given setup is enough to now do some common operations on our Helm chart source code.
 
-### Linting
+#### Linting
 
 The Helm backend has an implementation of the Pants' `lint` goal which hooks it with the `helm lint` command:
 
@@ -100,7 +100,7 @@ Likewise, in a similar way you could enable strict linting globally and then cho
 
 You can set the field `skip_lint=True` on each `helm_chart` target to avoid linting it.
 
-### Package
+#### Package
 
 Packing helm charts is supported out of the box via the Pants' `package` goal. The final package will be saved as a `.tgz` file under the `dist` folder at your source root.
 
@@ -113,7 +113,7 @@ Built Helm chart artifact: testprojects.src.helm.example/example/example-0.2.0.t
 
 The final output folder can customised using the `output_path` field in the `helm_chart` target. Run `pants help helm_chart` for more information.
 
-### Helm chart version
+#### Helm chart version
 
 Helm charts are versioned artifacts with the value of the `version` field in `Chart.yaml` determining the actual version of the chart. Pants needs to know the version of a first party chart to be able to build packages and correctly establish the dependencies among them. By default, Pants will use the value in `Chart.yaml` as the given version of a chart but it also supports overriding that value via the `version` field in the `helm_chart` target.
 
@@ -153,7 +153,7 @@ helm_chart(version=env('HELM_CHART_VERSION'))
 
 Now the version value for this chart will be what has been set as the value of the environment variable `HELM_CHART_VERSION`.
 
-# Helm Unit tests
+## Helm Unit tests
 
 The Helm backend supports running Helm unit tests via the [Helm `unittest` plugin](https://github.com/quintush/helm-unittest). To run unit tests follow the instructions on how to use that plugin and then create a `BUILD` file in the same folder where your tests live with the following target:
 
@@ -201,7 +201,7 @@ pants test ::
 ✓ testprojects/src/helm/example/tests/env-configmap_test.yaml succeeded in 0.75s.
 ```
 
-### Feeding additional files to unit tests
+#### Feeding additional files to unit tests
 
 In some cases we may want our tests to have access to additional files which are not part of the chart. This can be achieved by setting a dependency between our unit test targets and a `resources` target as follows:
 
@@ -304,7 +304,7 @@ not affected by the source roots setting. When using `relocated_files`, the file
 to the value set in the `dest` field.
 :::
 
-### Snapshot testing
+#### Snapshot testing
 
 Unit test snapshots are supported by Pants by wrapping the snapshots in resources targets, as shown in the previous section. Snapshot resources will be automatically inferred as dependencies of the tests where they reside, so there is no need to add a explicit `dependencies` relationship in your `helm_unittest_tests` targets.
 
@@ -318,7 +318,7 @@ This will generate test snapshots for tests that require them, with out-of-date 
 
 If new `__snapshot__` folders are created after running the `generate-snapshots` target, we recommend running the `tailor` goal again so that Pants can detect these new folders and create `resources` targets as appropriate.
 
-### Timeouts
+#### Timeouts
 
 Pants can cancel tests that take too long, which is useful to prevent tests from hanging indefinitely.
 
@@ -352,13 +352,13 @@ If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will 
 
 Use the option `pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
-# Publishing Helm charts
+## Publishing Helm charts
 
 Pants only supports publishing Helm charts to OCI registries, a feature that was made generally available in Helm 3.8.
 
 The publishing is done with Pants' `publish` goal but first you will need to tell Pants what are the possible destination registries where to upload your charts.
 
-## Configuring OCI registries
+### Configuring OCI registries
 
 In a similar way as the `docker_image` target, a `helm_chart` target takes an optional `registries` field whose value is a list of registry endpoints (prefixed by the `oci://` protocol):
 
@@ -406,7 +406,7 @@ helm_chart(
 )
 ```
 
-## Setting a repository name
+### Setting a repository name
 
 When publishing charts into an OCI registry, you most likely will be interested on separating them from other kind of OCI assets (i.e. container images). For doing so you can set a `repository` field in the `helm_chart` target so the chart artifact will be uploaded to the given path:
 
@@ -426,7 +426,7 @@ You can also set a default global repository in `pants.toml` as in the following
 default_registry_repository = "charts"
 ```
 
-# Managing Chart Dependencies
+## Managing Chart Dependencies
 
 Helm charts can depend on other charts, whether first-party charts defined in the same repo, or third-party charts published in a registry. Pants uses this dependency information to know when work needs to be re-run.
 
@@ -434,7 +434,7 @@ Helm charts can depend on other charts, whether first-party charts defined in th
 To benefit from Pants dependency management and inference in your Helm charts, you will need to use `apiVersion: v2` in your `Chart.yaml` file.
 :::
 
-## `Chart.yaml` dependencies
+### `Chart.yaml` dependencies
 
 Pants will automatically infer dependencies from the `Chart.yaml` file.
 
@@ -471,7 +471,7 @@ pants dependencies src/helm/bar
 src/helm/foo
 ```
 
-## Explicitly provided dependencies in `BUILD` files
+### Explicitly provided dependencies in `BUILD` files
 
 If you prefer, you can let your BUILD files be the "source of truth" for dependencies, instead of specifying them in `Chart.yaml`:
 
@@ -499,7 +499,7 @@ helm_chart(dependencies=["//src/helm/foo"])
 
 In this case, the `pants dependencies` command will show the same result and, in addition, Pants will modify its copy of `bar`'s `Chart.yaml` before using it, so that it includes `foo` in its dependency list. Note that Pants will not modify the original copy in your source tree, only the copy it uses in the sandboxed execution environment.
 
-## Third party chart artifacts
+### Third party chart artifacts
 
 Third party charts are provided to Pants using the `helm_artifact` target:
 

--- a/versioned_docs/version-2.19/docs/introduction/welcome-to-pants.mdx
+++ b/versioned_docs/version-2.19/docs/introduction/welcome-to-pants.mdx
@@ -5,11 +5,11 @@
 
 ---
 
-# What is Pants?
+## What is Pants?
 
 Pants is a fast, scalable, user-friendly build and developer workflow system for codebases of all sizes, including yours!
 
-# What does Pants do?
+## What does Pants do?
 
 Pants installs, orchestrates and runs dozens of standard underlying tools - compilers, code generators, dependency resolvers, test runners, linters, formatters, packagers, REPLs and more - composing them into a single stable, hermetic toolchain, and speeding up your workflows via caching and concurrency.
 
@@ -17,13 +17,13 @@ Pants is designed to be easy to adopt, use, and extend. It doesn't require you t
 
 Pants is currently focused on Python, Go, Java, Scala, Shell, and Docker, with more languages and frameworks coming soon. [The Pants community](/community/members) is friendly and helpful and welcomes involvement of anyone who is interested in creating modern software development tooling.
 
-# Who is Pants for?
+## Who is Pants for?
 
 Pants is useful for repos of all sizes, but is particularly valuable for those containing multiple distinct but interdependent pieces.
 
 Pants works well with (but does not require) a [_monorepo_ architecture](https://blog.pantsbuild.org/the-monorepo-approach-to-code-management/): a codebase containing multiple projects—often using multiple programming languages and frameworks—in a single unified repository. If you want to scale your codebase without breaking it up into multiple disconnected repos, with all the versioning and maintenance headaches that causes, Pants provides the tooling for you to do so effectively.
 
-# What are the main features of Pants?
+## What are the main features of Pants?
 
 Pants is designed for fast, consistent, ergonomic builds. Some noteworthy features include:
 
@@ -36,7 +36,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 - Extensibility and customizability via a plugin API
 - Code introspection features
 
-# Which languages and frameworks does Pants support?
+## Which languages and frameworks does Pants support?
 
 - Pants [ships](page:language-support) with support for [Python](../python/overview/index.mdx), [Go](../go/index.mdx), [Java](../java-and-scala/index.mdx), [Scala](../java-and-scala/index.mdx) and [Shell](../shell/index.mdx).
 - Pants supports a wide range of code generators (such as Thrift, Protobuf, Scrooge and Avro), linters and formatters, and it is easy to add support for new or custom ones
@@ -45,7 +45,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 We're listening to the community for which languages, frameworks and tools we should support next, so let us know about your needs by [opening an issue](https://github.com/pantsbuild/pants/issues/new/choose) on GitHub or [chatting with us](/community/members) about it on the community Slack!
 Pants was designed for extensibility, and we welcome [contributions](../contributions/index.mdx)!
 
-# How does Pants work?
+## How does Pants work?
 
 The core of Pants is its execution engine, which sequences and coordinates all the underlying work. The engine is written in Rust, for performance. The underlying work is performed by executing _rules_, which are typed Python 3 async coroutines for familiarity and simplicity.
 
@@ -53,17 +53,17 @@ The engine is designed so that fine-grained invalidation, concurrency, hermetici
 
 See [here](./how-does-pants-work.mdx) for more details about the Pants engine.
 
-# Is Pants similar to X?
+## Is Pants similar to X?
 
 Pants (v2) is a leap forward in the evolution of build systems, a category that runs from the venerable Make through Ant, Maven, Gradle and SBT, to Bazel, Please, Buck, Pants v1 and others.
 
 Its design leans on ideas and inspiration from these earlier tools, while optimizing not just for speed and correctness, but also for ease of adoption, ease of use and ease of extension, all for real-world use cases at a variety of teams.
 
-# Who uses Pants?
+## Who uses Pants?
 
 Pants is making engineering teams productive and happy at a range of companies and organizations. See a sample of them [here](page:who-uses-pants)!
 
-# Who develops Pants?
+## Who develops Pants?
 
 Pants is an open-source software project, developed at [github.com/pantsbuild/pants](https://github.com/pantsbuild/pants). Pants is released under the [Apache License 2.0](https://github.com/pantsbuild/pants/blob/master/LICENSE).
 

--- a/versioned_docs/version-2.19/docs/terraform/index.mdx
+++ b/versioned_docs/version-2.19/docs/terraform/index.mdx
@@ -11,7 +11,7 @@ Pants is currently building support for developing and deploying Terraform. Simp
 Please share feedback for what you need to use Pants with your Terraform modules and deployments by either [opening a GitHub issue](https://github.com/pantsbuild/pants/issues/new/choose) or [joining our Slack](/community/getting-help)!
 :::
 
-# Initial setup
+## Initial setup
 
 First, activate the relevant backend in `pants.toml`:
 
@@ -26,14 +26,14 @@ backend_packages = [
 
 The Terraform backend also needs Python to run Pants's analysers. The setting `[python].interpreter_constraints` will need to be set.
 
-## Adding Terraform targets
+### Adding Terraform targets
 
 The Terraform backend has 2 target types:
 
 - `terraform_module` for Terraform source code
 - `terraform_deployment` for deployments that can be deployed with the `experimental-deploy` goal
 
-### Modules
+#### Modules
 
 The `tailor` goal will automatically generate `terraform_module` targets. Run [`pants tailor ::`](../getting-started/initial-configuration.mdx#5-generate-build-files). For example:
 
@@ -43,7 +43,7 @@ Created src/terraform/root/BUILD:
   - Add terraform_module target root
 ```
 
-### Deployments
+#### Deployments
 
 `terraform_deployments` must be manually created. The deployment points to a `terraform_module` target as its `root_module` field. This module will be the "root" module that Terraform operations will be run on. You can reference vars files with the `var_files` field. You can have multiple deployments reference the same module:
 
@@ -53,7 +53,7 @@ terraform_deployment(name="prod", root_module=":root", var_files=["prod.tfvars"]
 terraform_deployment(name="test", root_module=":root", var_files=["test.tfvars"])
 ```
 
-### Lockfiles
+#### Lockfiles
 
 Automatic lockfile management is currently in progress. You can include lockfiles manually as a dependency:
 
@@ -62,9 +62,9 @@ terraform_deployment(name="prod", root_module=":root", dependencies=[":lockfile"
 file(name="lockfile", source=".terraform.lock.hcl")
 ```
 
-## Basic Operations
+### Basic Operations
 
-### Formatting
+#### Formatting
 
 Run `terraform fmt` as part of the `fix`, `fmt`, or `lint` goals.
 
@@ -75,7 +75,7 @@ pants fix ::
 ✓ terraform-fmt made no changes.
 ```
 
-### Validate
+#### Validate
 
 Run `terraform validate` as part of the `check` goal.
 
@@ -94,7 +94,7 @@ Success! The configuration is valid.
 terraform_module(skip_terraform_validate=True)
 ```
 
-### Deploying
+#### Deploying
 
 :::caution Terraform deployment support is in alpha stage
 Many options and features aren't supported yet.

--- a/versioned_docs/version-2.19/docs/using-pants/environments.mdx
+++ b/versioned_docs/version-2.19/docs/using-pants/environments.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Environments
+## Environments
 
 :::caution Environments are currently in `preview`, and have not yet stabilized.
 We'd love your feedback on how Environments could be most useful to you! Please refer to [the tracking issue](https://github.com/pantsbuild/pants/issues/17355) for known stabilization blockers.
@@ -17,7 +17,7 @@ By default, Pants will execute all sandboxed build work directly on localhost. B
 2. remotely via [remote execution](./remote-caching-&-execution/remote-execution.mdx)
 3. locally, but with a non-default set of environment variables and settings (such as when different platforms need different values, or when cross-building)
 
-## Defining environments
+### Defining environments
 
 Environments are defined using environment targets:
 
@@ -53,7 +53,7 @@ docker_environment(
 Environment targets are loaded before regular targets in a bootstrap phase, during which macros are unavailable. As such any required field values must be fully defined in the BUILD file without referencing any macros. For optional fields, the use of macros are still discouraged as it may or may not work and Pants makes no guarantees that it will not break in a future version if it were to currently work.
 :::
 
-### Environment-aware options
+#### Environment-aware options
 
 Environment targets have fields ([target](./key-concepts/targets-and-build-files.mdx) arguments) which correspond to [options](./key-concepts/options.mdx) which are marked "environment-aware". When an option is environment-aware, the value of the option that will be used in an environment can be overridden by setting the corresponding field value on the associated environment target. If an environment target does not set a value, it defaults to the value which is set globally via options values.
 
@@ -63,7 +63,7 @@ For example, the [`[python-bootstrap].search_path` option](../../reference/subsy
 Environments are a new concept: if you see an option value which should be marked environment-aware but isn't, please definitely [file an issue](https://github.com/pantsbuild/pants/issues/new/choose)!
 :::
 
-## Consuming environments
+### Consuming environments
 
 To declare which environment they should build with, many target types (but particularly "root" targets like tests or binaries) have an `environment=` field: for example, [`python_tests(environment=..)`](../../reference/targets/python_tests.mdx#environment).
 
@@ -78,7 +78,7 @@ Currently, there is no static validation that a target's environment is compatib
 As we gain more experience with how environments are used in the wild, it's possible that more static validation can be added: your feedback would be very welcome!
 :::
 
-### Setting the environment on many targets at once
+#### Setting the environment on many targets at once
 
 To use an environment everywhere in your repository (or only within a particular subdirectory, or with a particular target
 type), you can use the [`__defaults__` builtin](./key-concepts/targets-and-build-files.mdx#field-default-values). For example, to use an environment named `my_default_environment` globally by default, you would add the following to a `BUILD` file at the root of the repository:
@@ -89,7 +89,7 @@ __defaults__(all=dict(environment="my_default_environment"))
 
 ... and individual targets could override the default as needed.
 
-### Building one target in multiple environments
+#### Building one target in multiple environments
 
 If a target will always need to be built in multiple environments (rather than conditionally based on which user is building it: see the "Toggle use of an environment for some consumers" section), then you can use the [`parametrize` builtin](./key-concepts/targets-and-build-files.mdx#parametrizing-targets) for the `environment=` field. If you had two environments named `linux` and `macos`, that would look like:
 
@@ -100,7 +100,7 @@ pex_binary(
 )
 ```
 
-### Environment matching
+#### Environment matching
 
 A single environment name may end up referring to different environment targets on different physical machines, or with different global settings applied: this is known as environment "matching".
 
@@ -133,9 +133,9 @@ docker_environment(
 
 In future versions, environment targets will gain additional predicates to control whether they match (for example: `local_environment` will likely gain a predicate that looks for the [presence or value of an environment variable](https://github.com/pantsbuild/pants/issues/17107). But in the meantime, it's possible to override which environments are matched for particular use cases by overriding their configured names: see the "Toggle use of an environment" workflow below for an example.
 
-## Example workflows
+### Example workflows
 
-### Enabling remote execution globally
+#### Enabling remote execution globally
 
 `remote_environment` targets match unless the [`--remote-execution`](../../reference/global-options.mdx#remote_execution) option is disabled. So to cause a particular environment name to use remote execution whenever it is enabled, you could define environment targets which try remote execution first, and then fall back to local execution:
 
@@ -167,7 +167,7 @@ local = "//:local"
 The `2.15.x` series of Pants does not yet support ["speculating" remote execution](https://github.com/pantsbuild/pants/issues/8353) by racing it against another environment (usually local or docker). While we expect that this will be necessary to make remote execution a viable option for local execution on user's laptops (where network connections are less reliable), it is less critical for CI use-cases.
 :::
 
-### Use a `docker_environment` to build the inputs to a `docker_image`
+#### Use a `docker_environment` to build the inputs to a `docker_image`
 
 To build a `docker_image` target containing a `pex_binary` which uses native (i.e. compiled) dependencies on a `macOS` machine, you can configure the `pex_binary` to be built in a `docker_environment`.
 
@@ -206,7 +206,7 @@ Note that the Docker image used in your `docker_environment` does not need to ma
 This means that your `docker_environment` can include things like compilers or other tools relevant to your build, without needing to manually use multi-stage Docker builds.
 :::
 
-### Toggle use of an environment for some consumers
+#### Toggle use of an environment for some consumers
 
 As mentioned above in "Environment matching", environment targets "match" based on their field values and global options. But if two environment targets would be ambiguous in some cases, or if you'd otherwise like to control what a particular environment name means (in CI, for example), you can override an environment name via options.
 

--- a/versioned_docs/version-2.19/docs/using-pants/key-concepts/goals.mdx
+++ b/versioned_docs/version-2.19/docs/using-pants/key-concepts/goals.mdx
@@ -17,7 +17,7 @@ To see the current list of goals, run:
 
 You'll see more goals activated as you activate more [backends](./backends.mdx).
 
-# Running goals
+## Running goals
 
 For example:
 
@@ -48,7 +48,7 @@ Finally, Pants supports running goals in a `--loop`. In this mode, all goals spe
 
 Use `Ctrl+C` to exit the `--loop`.
 
-# Goal arguments
+## Goal arguments
 
 Most goals require arguments to know what to work on.
 
@@ -71,7 +71,7 @@ To ignore something, prefix the argument with `-`. For example, `pants test :: -
 See [Advanced target selection](../advanced-target-selection.mdx) for alternative techniques to specify which files/targets to run on.
 :::
 
-## Goal options
+### Goal options
 
 Many goals also have [options](./options.mdx) to change how they behave. Every option in Pants can be set via an environment variable, config file, and the command line.
 

--- a/versioned_docs/version-2.19/docs/using-pants/key-concepts/options.mdx
+++ b/versioned_docs/version-2.19/docs/using-pants/key-concepts/options.mdx
@@ -7,7 +7,7 @@ A deep dive into how options may be configured.
 
 ---
 
-# Option scopes
+## Option scopes
 
 Options are partitioned into named _scopes_.
 
@@ -15,7 +15,7 @@ Some systemwide options belong in the _global scope_. For example, the `--level`
 
 Other options belong to a _subsystem scope_. A _subsystem_ is simply a collection of related options, in a scope. For example, the `pytest` subsystem contains options related to [Python's test framework pytest](../../../reference/subsystems/pytest.mdx).
 
-# Setting options
+## Setting options
 
 Every option can be set in the following ways, in order of precedence:
 
@@ -27,7 +27,7 @@ If an option isn't set in one of these ways, it will take on a default value.
 
 You can inspect both the current value and the default value by using `pants help $scope` or `pants help-advanced $scope`, e.g. `pants help global`.
 
-## Command-line flags
+### Command-line flags
 
 Global options are set using an unqualified flag:
 
@@ -41,7 +41,7 @@ Subsystem options are set by providing the flag, with the name prefixed with the
 pants --source-root-patterns="['^ext']"
 ```
 
-## Environment variables
+### Environment variables
 
 Global options are set using the environment variable `PANTS_{OPTION_NAME}`:
 
@@ -58,7 +58,7 @@ PANTS_SOURCE_ROOT_PATTERNS="['^ext']" pants ...
 
 Note that the scope and option name are upper-cased, and any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `MULTIWORD_NAME`.
 
-## Config file entries
+### Config file entries
 
 Global options are set in the `GLOBAL` section of the config file:
 
@@ -76,7 +76,7 @@ root_patterns = ["/src/python"]
 
 Note that any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `multiword_name`.
 
-### Config file interpolation
+#### Config file interpolation
 
 Environment variables can be interpolated by using the syntax `%(env.ENV_VAR)s`, e.g.:
 
@@ -95,7 +95,7 @@ Additionally, a few special values are pre-populated with the `%(var)s` syntax:
 - `%(pants_distdir)s`: absolute path of the global option `--pants-distdir`, which defaults
   to `{buildroot}/dist/`
 
-# Option types
+## Option types
 
 Every option has a type, and any values you set must be of that type.
 
@@ -109,25 +109,25 @@ The option types are:
 
 A list-valued option may also declare a specific type for its members (e.g., a list of strings, or a list of integers).
 
-## String and integer values
+### String and integer values
 
 Standalone string and integer values are written without quotes. Any quotes will be considered part of the value, after shell escaping.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-intopt=42
 pants --scope-stropt=qux
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_INTOPT=42
 PANTS_SCOPE_STROPT=qux
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -135,11 +135,11 @@ intopt = 42
 stropt = "qux"
 ```
 
-## Boolean values
+### Boolean values
 
 Boolean values can be specified using the special strings `true` and `false`. When specifying them via command-line flags you can also use the `--boolopt/--no-boolopt` syntax.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-boolopt=true
@@ -147,24 +147,24 @@ pants --scope-boolopt
 pants --no-scope-boolopt
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_BOOLOPT=true
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
 boolopt = true
 ```
 
-## List values
+### List values
 
 List values are parsed as Python list literals, so you must quote string values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-listopt="['foo','bar']"
@@ -178,7 +178,7 @@ pants --scope-listopt=foo --scope-listopt=bar
 
 Appending will add to any values from lower-precedence sources, such as config files (`pants.toml`) and possibly Pants's `default`. Otherwise, using `[]` will override any lower-precedence sources.
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_LISTOPT="['foo','bar']"
@@ -190,7 +190,7 @@ Like with command-line flags, you can leave off the `[]` to _append_ elements:
 PANTS_SCOPE_LISTOPT=foo
 ```
 
-### Config file entries:
+#### Config file entries:
 
 ```toml title="pants.toml"
 [scope]
@@ -200,7 +200,7 @@ listopt = [
 ]
 ```
 
-### Add/remove semantics
+#### Add/remove semantics
 
 List values have some extra semantics:
 
@@ -250,23 +250,23 @@ listopt.remove = [3, 4]
 But note that this only works in Pants's `.toml` config files, not in environment variables or command-line flags.
 :::
 
-## Dict values
+### Dict values
 
 Dict values are parsed as Python dict literals on the command-line and environment variables, so you must quote string keys and values, and you may need to apply shell-level quoting and/or escaping, as required.
 
-### Command-line flags:
+#### Command-line flags:
 
 ```bash
 pants --scope-dictopt="{'foo':1,'bar':2}"
 ```
 
-### Environment variables:
+#### Environment variables:
 
 ```bash
 PANTS_SCOPE_DICTOPT="{'foo':1,'bar':2}"
 ```
 
-### Config file entries:
+#### Config file entries:
 
 You can use TOML's [nested table features](https://toml.io/en/v1.0.0#inline-table). These are equivalent:
 
@@ -291,7 +291,7 @@ dictopt = """{
 }"""
 ```
 
-### Add/replace semantics
+#### Add/replace semantics
 
 - A value can be preceded by `+`, which will _update_ the value obtained from lower-precedence sources with the entries.
 - Otherwise, the value _replaces_ the one obtained from lower-precendence sources.
@@ -310,7 +310,7 @@ pants --scope-dictopt="{'foo':42,'baz':3}"
 
 will set the value to `{'foo': 42, 'baz': 3}`.
 
-# Reading individual option values from files
+## Reading individual option values from files
 
 If an option value is too large or elaborate to use directly, or if you don't want to hard-code
 values directly in `pants.toml`, you can set the value of any option to the string
@@ -345,7 +345,7 @@ do so by `kill`ing it (after using `ps -ef | grep pantsd` to find its pid), or b
 Pants once with `--no-pantsd`.
 :::
 
-# `.pants.rc` file
+## `.pants.rc` file
 
 You can set up personal Pants config files, using the same TOML syntax as `pants.toml`. By default, Pants looks for the paths `/etc/pantsrc`, `~/.pants.rc`, and `.pants.rc` in the repository root.
 

--- a/versioned_docs/version-2.19/docs/using-pants/key-concepts/source-roots.mdx
+++ b/versioned_docs/version-2.19/docs/using-pants/key-concepts/source-roots.mdx
@@ -13,7 +13,7 @@ Go does have a notion of source roots: where your `go.mod` is located. However, 
 Shell does not have any notion of source roots.
 :::
 
-# What are source roots?
+## What are source roots?
 
 Some project layouts use top-level folders for namespace purposes, but have the code live underneath. However, the code's imports will ignore these top-level folders, thanks to mechanisms like the `$PYTHONPATH` and the JVM classpath. _Source roots_ are a generic equivalent of these concepts.
 
@@ -44,7 +44,7 @@ pkgutil.get_data("project.config", "prod.json")
 
 In the example above, `src/python` is a source root. So, when some code says `from project.app import App`, Pants can know that this corresponds to the code in `src/python/project/app.py`.
 
-# Configuring source roots
+## Configuring source roots
 
 There are two ways to configure source roots:
 
@@ -60,7 +60,7 @@ src/python
 src/rust
 ```
 
-## Configuring source roots using patterns
+### Configuring source roots using patterns
 
 You can provide a set of patterns that match your source roots:
 
@@ -85,7 +85,7 @@ You can use `*` as a glob. For example, `root_patterns = ["/src/*"]` would consi
 - `src/java`
 - `src/assets`
 
-### Configuring no source roots
+#### Configuring no source roots
 
 Many projects do not have any top-level folders used for namespacing.
 
@@ -125,7 +125,7 @@ The default value of the `root_patterns` config key is `["/", "src", "src/python
 These capture a range of common cases, including a source root at the root of the repository. If your source roots match these patterns, you don't need to explicitly configure them.
 :::
 
-## Configuring source roots using marker files
+### Configuring source roots using marker files
 
 You can also denote your source roots using specially-named marker files. To do so, first pick a name (or multiple names) to use:
 
@@ -182,15 +182,15 @@ import server.server.app
 from utils.utils.strutil import capitalize
 ```
 
-# Examples
+## Examples
 
 These project structures are all valid; Pants does not expect you to reorganize your codebase to use the tool.
 
-## `src/<lang>` setup
+### `src/<lang>` setup
 
 This setup is common in "polyglot" repositories: i.e. repos with multiple languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -228,7 +228,7 @@ This setup is common in "polyglot" repositories: i.e. repos with multiple langua
 
 While we have tests in a separate source root here, it's also valid to have tests colocated with their src files.
 
-### Example imports:
+#### Example imports:
 
 ```python
 # Python
@@ -242,7 +242,7 @@ import org.pantsbuild.project.App
 import org.pantsbuild.project.util.Math
 ```
 
-### Config:
+#### Config:
 
 ```toml title="pants.toml"
 [source]
@@ -255,9 +255,9 @@ root_patterns = [
 
 Note that we organized our 3rdparty requirements in the top-level folders `3rdparty/python` and `3rdparty/java`, but we do not need to include them as source roots because we do not have any first-party code there.
 
-## Multiple top-level projects
+### Multiple top-level projects
 
-### Project:
+#### Project:
 
 This layout has lots of nesting; this is only one possible way to organize the repository.
 
@@ -289,7 +289,7 @@ This layout has lots of nesting; this is only one possible way to organize the r
         └── spa.js
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 import ads.billing.calculate_bill
@@ -299,7 +299,7 @@ from base.util.math import add_two
 
 Note that even though the projects live in different top-level folders, you are still able to import from other projects. If you would like to limit this, you can use `pants dependents` or `pants dependencies` in CI to track where imports are being used. See [Project introspection](../project-introspection.mdx).
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 
@@ -320,11 +320,11 @@ root_patterns = [
 ]
 ```
 
-## No source root
+### No source root
 
 Warning: while this project structure is valid, it often does not scale as well as your codebase grows, such as adding new languages.
 
-### Project:
+#### Project:
 
 ```
 .
@@ -340,7 +340,7 @@ Warning: while this project structure is valid, it often does not scale as well 
 └── pyproject.toml
 ```
 
-### Example imports:
+#### Example imports:
 
 ```python
 from project.app import App
@@ -349,7 +349,7 @@ from project.util.math import add_two
 pkgutil.get_data("project.config", "prod.json")
 ```
 
-### Config:
+#### Config:
 
 Either of these are valid and they have the same result:
 

--- a/versioned_docs/version-2.19/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/versioned_docs/version-2.19/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -23,7 +23,7 @@ To reduce boilerplate, some targets also generate other targets:
 - `shell_sources` -> `shell_source`
 - `go_mod` -> `go_third_party_package`
 
-# BUILD files
+## BUILD files
 
 Targets are defined in files with the name `BUILD`. For example:
 
@@ -45,7 +45,7 @@ All target types have a `name` field, which is used to identify the target. Targ
 
 You can autoformat `BUILD` files by enabling a `BUILD` file formatter by adding it to `[GLOBAL].backend_packages` in `pants.toml` (such as `pants.backend.build_files.fmt.black` [or others](./backends.mdx)). Then to format, run `pants fmt '**/BUILD'` or `pants fmt ::` (formats everything).
 
-## Environment variables
+### Environment variables
 
 BUILD files are very hermetic in nature with no support for using `import` or other I/O operations. In order to have dynamic data in BUILD files, you may inject values from the local environment using the `env()` function. It takes the variable name and optional default value as arguments.
 
@@ -60,7 +60,7 @@ python_distribution(
 )
 ```
 
-# Target addresses
+## Target addresses
 
 A target is identified by its unique address, in the form `path/to/dir:name`. The above example has the addresses `helloworld/greet:tests` and `helloworld/greet:bin`.
 
@@ -83,7 +83,7 @@ You can refer to this target with either `helloworld/greet:greet` or the abbrevi
 Addresses defined in the `BUILD` file at the root of your repository are prefixed with `//`, e.g. `//:my_tgt`.
 :::
 
-# `source` and `sources` field
+## `source` and `sources` field
 
 Targets like `python_test` and `resource` have a `source: str` field, while target generators like `python_tests` and `resources` have a `sources: list[str]` field. This determines which source files belong to the target.
 
@@ -123,7 +123,7 @@ Including the same file in the `source` / `sources` field for multiple targets c
 You can run `pants list path/to/file.ext` to see all "owning" targets to check if >1 target has the file in its `source` field.
 :::
 
-# `dependencies` field
+## `dependencies` field
 
 A target's dependencies determines which other first-party code and third-party requirements to include when building the target.
 
@@ -166,7 +166,7 @@ You can use the prefix `!!` to transitively exclude a dependency, meaning that e
 Transitive excludes can only be used in target types that conventionally are not depended upon by other targets, such as `pex_binary`, `python_distribution`, and `python_test` / `python_tests`. This is meant to limit confusion, as using `!!` in something like a `python_source` / `python_sources` target could result in surprising behavior for everything that depends on it. (Pants will print a helpful error when using `!!` when it's not legal.)
 :::
 
-# Field default values
+## Field default values
 
 As mentioned above in [BUILD files](./targets-and-build-files.mdx#build-files), most target fields have sensible defaults. And it's easy to override those values on a specific target. But applying the same non-default value on many targets can get unwieldy, error-prone and hard to maintain. Enter `__defaults__`.
 
@@ -215,7 +215,7 @@ To reset any modified defaults, simply override with the empty dict:
     __defaults__(all={})
 ```
 
-## Supporting optional plugin fields
+### Supporting optional plugin fields
 
 Normally Pants presents an error message when attempting to provide a default value for a field that doesn't exist for the target. However, some fields comes from plugins, and to support disabling a plugin without having to remove any default values referencing any plugin fields it was providing, there is a `ignore_unknown_fields` option to use:
 
@@ -228,7 +228,7 @@ Normally Pants presents an error message when attempting to provide a default va
     )
 ```
 
-## Extending field defaults
+### Extending field defaults
 
 To add to a default value rather than replacing it, the current default value for a target field is available in the BUILD file using `<target>.<field>.default`. This allows you to augment a field's default value with much more precision. As an example, if you want to make the default sources for a `python_sources` target to work recursively you may specify a target augmenting the default sources field:
 
@@ -242,7 +242,7 @@ python_sources(
 )
 ```
 
-# Target generation
+## Target generation
 
 To reduce boilerplate, Pants provides target types that generate other targets. For example:
 
@@ -320,7 +320,7 @@ It's useful for metadata to be as fine-grained as feasible, such as by using the
 [`pants tailor ::`](../../getting-started/initial-configuration.mdx#5-generate-build-files) will automatically create targets that only apply metadata for the directory.
 :::
 
-# Parametrizing targets
+## Parametrizing targets
 
 It can be useful to create multiple targets describing the same entity, each with different metadata. For example:
 

--- a/versioned_docs/version-2.19/docs/using-pants/remote-caching-&-execution/index.mdx
+++ b/versioned_docs/version-2.19/docs/using-pants/remote-caching-&-execution/index.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# Overview
+## Overview
 
 By default, Pants executes processes in a local [environment](../environments.mdx) on the system on which it is run, and caches the results of those processes locally as well. Besides this "local execution" mode of operation, Pants also supports two distributed modes of operation:
 
@@ -15,7 +15,7 @@ By default, Pants executes processes in a local [environment](../environments.md
 
 Pants does this by using the "Remote Execution API" to converse with the remote cache or remote execution server. Pants also [supports some additional providers](./remote-caching.mdx) other than Remote Execution API that provide only remote caching, without execution.
 
-## What is Remote Execution API?
+### What is Remote Execution API?
 
 Pants is compatible with remote caching and remote execution servers that comply with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI protocol is supported by several different server and client projects including Bazel and of course Pants.
 
@@ -31,7 +31,7 @@ Pants calls the CAS a "store server" and the execution service an "execution ser
 
 The REAPI model contains the notion of an "instance." An "instance" is a distinct deployment of a CAS and/or execution service that is given a specific name. All REAPI operations send an instance name to the server, thus a single network endpoint can conceivably support multiple REAPI deployments.
 
-# Server compatibility
+## Server compatibility
 
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
@@ -53,6 +53,6 @@ Bazel Remote Cache supports local disk, S3, GCS, and Azure Blob storage options 
 
 There are a few [other](https://github.com/bazelbuild/remote-apis) systems and services in this space, but they have not, to our knowledge, been tested with Pants. Let us know if you have any experience with them!
 
-# Resources
+## Resources
 
 - The [remote-apis-testing project](https://gitlab.com/remote-apis-testing/remote-apis-testing) maintains a compatibility test suite of the various server and client implementations of REAPI.

--- a/versioned_docs/version-2.19/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
+++ b/versioned_docs/version-2.19/docs/using-pants/remote-caching-&-execution/remote-caching.mdx
@@ -5,7 +5,7 @@
 
 ---
 
-# What is remote caching?
+## What is remote caching?
 
 Remote caching allows Pants to store and retrieve the results of process execution to and from a remote server, rather than only using your machine's local Pants cache. This allows Pants to efficiently share a cache across different runs and different machines, for example, all of your CI workers sharing the same fine-grained cache.
 
@@ -15,13 +15,13 @@ Pants supports several remote caching providers:
 - GitHub Actions Cache
 - Local file system
 
-# Remote Execution API
+## Remote Execution API
 
-## Server
+### Server
 
 See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information about REAPI-compatible caches.
 
-## Pants Configuration
+### Pants Configuration
 
 After you have either set up a REAPI cache server or obtained access to one, the next step is to point Pants to it so that Pants will use it to read and write process results.
 
@@ -37,6 +37,6 @@ remote_instance_name = "main"
 
 If the endpoint is using TLS, then the `remote_store_address` option would be specified with the `grpcs://` scheme, i.e. `"grpcs://cache.corp.example.com:8980"`.
 
-# Reference
+## Reference
 
 Run `pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.

--- a/versioned_docs/version-2.19/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
+++ b/versioned_docs/version-2.19/docs/using-pants/remote-caching-&-execution/remote-execution.mdx
@@ -9,17 +9,17 @@
 Remote execution support in Pants comes with several limitations. For example, Pants requires that the server's operating system match the client's operating system. In practice, this means that Pants must be running on Linux because all three major server projects generally only operate on Linux.
 :::
 
-# What is remote execution?
+## What is remote execution?
 
 "Remote execution" allows Pants to offload execution of processes to a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"). The REAPI standard is supported by several different server and client projects including Bazel and of course Pants.
 
-# Setup
+## Setup
 
-## Server
+### Server
 
 Remote execution requires the availability of a REAPI-compatible execution server. See the [REAPI server compatibility guide](./index.mdx#server-compatibility) for more information.
 
-## Pants
+### Pants
 
 After you have either set up a REAPI server or obtained access to one, the next step is to point Pants to it so that Pants may submit REAPI execution requests. The server should be running a CAS and execution service. These may be the same network endpoint, but for Pants' purposes, they are configured by different configuration options.
 
@@ -33,7 +33,7 @@ remote_execution_address = "grpc://build.corp.example.com:8980"
 remote_instance_name = "main"
 ```
 
-### Environment-specific settings
+#### Environment-specific settings
 
 The REAPI execution service selects a worker for a process by consulting the "platform properties" that are passed in a remote execution request. These platform properties are key/value pairs that are configured for particular workers in the server. Generally, you will configure these in the server (or be provided them by your server's administrator), and then configure Pants to match particular workers using their relevant platform properties.
 
@@ -52,7 +52,7 @@ remote_environment(
 
 Your `remote_environment` will also need to override any [environment-aware options](../environments.mdx) which configure the relevant tools used in your repository. For example: if building Python code, a Python interpreter must be available and matched via the environment-aware options of `[python-bootstrap]`. If using protobuf support, then you may also need `unzip` available in the remote execution environment in order to unpack the protoc archive. Etc.
 
-### Concurrency
+#### Concurrency
 
 Finally, you should configure Pants to limit the number of concurrent execution requests that are sent to the REAPI server. The `process_execution_remote_parallelism` option controls this concurrency. For example, if `process_execution_remote_parallelism` is set to `20`, then Pants will only send a maximum of 20 execution requests at a single moment of time.
 
@@ -72,7 +72,7 @@ remote_execution_extra_platform_properties = [
 process_execution_remote_parallelism = 20
 ```
 
-### TLS
+#### TLS
 
 You can enable TLS by prefixing the `remote_store_address` and `remote_execution_address` with `grpcs://` instead of `grpc://`.
 
@@ -93,7 +93,7 @@ remote_client_certs_path = "/etc/ssl/certs/client-cert.pem"
 remote_client_key_path = "/etc/ssl/certs/client-key.pem"
 ```
 
-# Reference
+## Reference
 
 For global options, run `pants help-advanced global` or refer to [Global options](../../../reference/global-options.mdx). Most remote execution and caching options begin with the prefix `--remote`.
 

--- a/versioned_docs/version-2.19/docs/using-pants/validating-dependencies.mdx
+++ b/versioned_docs/version-2.19/docs/using-pants/validating-dependencies.mdx
@@ -76,7 +76,7 @@ backend_packages.add = [
 This does not mean you should not use it, only that it is in "preview" mode meaning that things may change between releases without following our deprecation policy as we work on stabilizing this feature. See [the stabilization ticket](https://github.com/pantsbuild/pants/issues/17634) for what remains to be done for the visibility backend to graduate out of preview.
 :::
 
-# Dependencies and dependents
+## Dependencies and dependents
 
 The visibility rules operates on the dependency link between two targets. Dependencies are directional, so if target `A` depends on another target `B` the dependency goes from the "origin" target `A` -> `B`, we say that `B` is the **dependency** of `A`, while `A` is the **dependent** of `B`.
 
@@ -180,7 +180,7 @@ If your codebase has a very complex dependency graph, you may need to make sure 
 
 In this scenario, you may need to look into alternative solutions to codify these constraints. For example, to check for violations, you could query the dependencies of component `C1` (transitively) using the `dependencies` goal with the `--transitive` option to confirm none of the modules from component `C3` are listed. If there are some, you may find the `paths` goal helpful as it would show you exactly why a certain module from component `C1` depends on a given module in component `C3` if it is unclear.
 
-## Rule sets
+### Rule sets
 
 As there may be many targets and files with dependencies, odds are that they won't all share the same set of rules. The rules keywords accepts multiple sets of rules, or "rule sets", along with "selector rules" that is used to select which set to use for each target.
 
@@ -289,7 +289,7 @@ The previous example, using this alternative syntax for the selectors, would loo
   )
 ```
 
-## Glob syntax
+### Glob syntax
 
 The visibility rules are all about matching globs. There are two wildcards: the `*` matches anything except `/`, and the `**` matches anything including `/`. (For paths that is non-recursive and recursive globbing respectively.)
 
@@ -319,7 +319,7 @@ some/directory/*
 
 So far the rule globs have been matched from anywhere in the matched to path up to the end. To ensure the path begins with a certain pattern we'd have to provide full paths in our rules, like `src/python/proj/lib/file.py` if we want to make sure that our `file.py` is from the `src/` tree. To avoid lengthy and rigid rule globs hurting refactorings etc, there's a concept of "anchoring" the rule. That will apply the rule glob from a fixed point in the matched to path, and there are three such points: project root, rule declaration path and rule invocation path. The difference between declaration and invocation is explained below.
 
-#### Anchoring mode for path globs
+##### Anchoring mode for path globs
 
 The glob prefix specifies which "anchoring mode" to use, and are:
 
@@ -340,7 +340,7 @@ The glob prefix specifies which "anchoring mode" to use, and are:
 
 > 🚧 Regardless of anchoring mode, all rules are always anchored to the end of the matched path.
 
-#### Targeting non-source files
+##### Targeting non-source files
 
 So far most examples have been about providing rules that match source files. This will likely be the most common scenario, but other targets may just as well need to be considered. For the general case, non-source file targets will be matched using the directory where it has been declared (the path containing the BUILD file in most cases).
 
@@ -391,7 +391,7 @@ __dependencies_rules__(
 )
 ```
 
-## Rule actions
+### Rule actions
 
 When a matching rule is found for a path, the path is either allowed or denied based on the rule's action. The dependency link as a whole is only allowed if both ends of the dependency allow it. By default a rule's action is `ALLOW`, but may be changed to `DENY` or `WARN`. The `WARN` action logs a warning message rather than raising an error, but will otherwise allow the dependency.
 


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pantsbuild.org/issues/112 by bumping all headers down one level if any of them are `h1`.

Replacement done via:

```python
def replace_headers(text: str):
    lines = text.splitlines(True)
    in_codeblock = False
    has_h1_header = False
    for index, line in enumerate(lines):
        if line.startswith("```"):
            in_codeblock = not in_codeblock
            continue

        if line.startswith("# ") and not in_codeblock:
            has_h1_header = True

        if line.startswith("#") and not in_codeblock and has_h1_header:
            lines[index] = "#" + line
    return "".join(lines)
```