### PR TITLE
Avoid duplicate h1 headings in blog posts

### DIFF
--- a/blog/2021-08-02-introducing-pants-2-6/index.mdx
+++ b/blog/2021-08-02-introducing-pants-2-6/index.mdx
@@ -18,7 +18,7 @@ We're pleased to announce Pants 2.6.0, the latest release of Pants, the scalable
 
 To update, set `pants_version = "2.6.0"` in your `pants.toml`. See [upgrade tips](https://www.pantsbuild.org/docs/upgrade-tips).
 
-# Poetry support
+## Poetry support
 
 Pants now understands Poetry's `pyproject.toml` configuration for third-party dependency management, addressing one of our most requested features in the last year!
 
@@ -26,7 +26,7 @@ Poetry support makes it even easier [to incrementally adopt Pants](https://www.p
 
 See our recent blog post ["Poetry support for Pants 2.6"](../2021-07-29-poetry-support-for-pants-2-6/index.mdx) for a more detailed introduction, along with the personal story behind [Toolchain](https://toolchain.com/)'s intern Liam Wilson adding this highly requested feature.
 
-# Third-party type stubs and MyPy 0.900+
+## Third-party type stubs and MyPy 0.900+
 
 [MyPy 0.900+ no longer includes typeshed](https://mypy-lang.blogspot.com/2021/06/mypy-0900-released.html), meaning that you must now install type stubs for many popular libraries. For example, you must install `types-requests` when using the `requests` library for MyPy to work properly.
 
@@ -44,7 +44,7 @@ The default for `[mypy].version` is now `0.910`. When upgrading to Pants 2.6, yo
 
 Finally, MyPy `0.900+` now supports `pyproject.toml` config files. Pants 2.6 will auto-discover this config file.
 
-# Linter reports
+## Linter reports
 
 Previously, you could set `[lint].reports_dir` for Pants to instruct Flake8 and Bandit to write reports under that directory. This had [several issues](https://github.com/pantsbuild/pants/pull/12122), including that some tools like Bandit allow you to write multiple formats (e.g. text vs. JSON), and Pants assumed a single format.
 
@@ -52,7 +52,7 @@ Instead, now you directly tell Flake8 and Bandit to generate a report by setting
 
 You can also now use [MyPy's report generation](https://mypy.readthedocs.io/en/stable/config_file.html#report-generation), e.g. by setting `linecount_report = "reports"` in `mypy.ini`. Pants will capture all files under the `reports/` folder and write them to `dist/typecheck/mypy`.
 
-# Other changes
+## Other changes
 
 - Updated default versions for Black, Pylint, and Bandit.
 - New [plugin hook](https://github.com/pantsbuild/pants/pull/12091) for setting up Python tests, e.g. starting up databases before test runs.
@@ -61,7 +61,7 @@ You can also now use [MyPy's report generation](https://mypy.readthedocs.io/en/s
 
 See the full [changelog](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.6.x.md) for more changes.
 
-## **Upcoming in Pants 2.7**
+### **Upcoming in Pants 2.7**
 
 We have been re-envisioning Pants's support for Python third-party dependencies to be more ergonomic, flexible, and safe. The changes include:
 

--- a/blog/2021-09-27-contributing-yapf-support/index.mdx
+++ b/blog/2021-09-27-contributing-yapf-support/index.mdx
@@ -48,7 +48,7 @@ Pants even facilitates incrementally adding YAPF to your codebase. You can tell 
 python_library(skip_yapf=True, skip_flake8=True)
 ```
 
-# My plugin development experience
+## My plugin development experience
 
 In my monorepo, there were already a few projects where YAPF was used, so it was important to make sure developers could continue using the same formatter after integrating the repository with Pants. Similarly, for any new projects to be added, it would be great to offer developers the flexibility to use another formatter in addition to Black.
 

--- a/blog/2022-09-01-introducing-pants-2-13/index.mdx
+++ b/blog/2022-09-01-introducing-pants-2-13/index.mdx
@@ -22,7 +22,7 @@ We're pleased to announce Pants 2.13.0, the latest release of Pants, the scalabl
 
 You can update by setting `pants_version = "2.13.0"` in your `pants.toml` file. See [upgrade tips](https://www.pantsbuild.org/docs/upgrade-tips) for more information.
 
-# Making it easier to work with file sets at the command line
+## Making it easier to work with file sets at the command line
 
 We've improved our command line arguments to make it easier to run Pants against multiple files, and making the behavior of different goals more consistent, so they're easier to learn and remember.
 
@@ -37,7 +37,7 @@ You can now easily run Pants against all targets in a directory by [specifying a
 
 Finally, you can now supply files to any Pants goal in the same way! Previously, some goals handled arguments in their own way, making it difficult to switch between goals, or use multiple goals for the same invocation. Now, the `::` glob, or the `--changed-since` command line option works for any goal that needs a list of targets. For example, try `./pants count-loc ::` to get the lines of code in your project (previously, you'd need to use `**`), or `./pants --changed-since=HEAD update-build-files` to only format changed `BUILD` files \[[#15577](https://github.com/pantsbuild/pants/pull/15577)\], \[[#14434](https://github.com/pantsbuild/pants/pull/14434)\]
 
-# Easy parallel execution in CI with test sharding
+## Easy parallel execution in CI with test sharding
 
 One goal of Pants is to make it easier to speed up your build and CI suites. Up until now, Pants' support for speeding up builds with parallelism has been limited to [remote execution](https://www.pantsbuild.org/v2.13/docs/remote-execution) services. Remote execution is highly flexible, at a cost of higher complexity.
 
@@ -45,13 +45,13 @@ For an easier first step into speeding up your test suite in CI, Pants 2.13 adds
 
 To enable, use the `PANTS_TEST_SHARD` environment variable or `--test-shard` command line option. Setting a value of `k/N` will deterministically split your test suite into `N` shards (by number of files only) and run the `k`th subset of that shard. \[[#15417](https://github.com/pantsbuild/pants/pull/15417)\]
 
-# Experimental Kotlin on JVM Support
+## Experimental Kotlin on JVM Support
 
 Fresh after adding support for Java and Scala, we've added initial support for Kotlin on the JVM, which brings all of the features from other JVM languages including multiple lockfile support for third-party dependencies, and JUnit for running your tests, along with integration with popular Kotlin tools including KtLint.
 
 Kotlin support is still work-in-progress, but we'd love for you to try it out and let us know how we can improve it.
 
-# Improved fine-tuning in JVM builds with per-tool options
+## Improved fine-tuning in JVM builds with per-tool options
 
 Following on from our initial experimental JVM support first released last year, Pants 2.13 now allows you to provide per-tool configuration for the underlying steps in your build. This is particularly handy for adjusting memory allocations for [more heavyweight compilers](https://www.scala-lang.org/) without increasing the memory for tools that don't need it.
 
@@ -59,11 +59,11 @@ The end result is that you should be able to run more JVM build steps in paralle
 
 To enable, you can set the `jvm_options` setting in the relevant tool's configuration block in your `pants.toml` file. See, for example, our [JUnit support documentation](https://www.pantsbuild.org/v2.13/docs/reference-junit#jvm_options). \[[#15505](https://github.com/pantsbuild/pants/pull/15505)\]
 
-# Improved IDE support for JVM languages
+## Improved IDE support for JVM languages
 
 Our Build Server Protocol-based IDE support has gained a few more features since the initial release in Pants 2.12. We now support automatic JDK configuration for Scala projects, and it's now possible for IntelliJ to run tests against class files that have been built by Pants \[[#15408](https://github.com/pantsbuild/pants/pull/15408)\], \[[#15347](https://github.com/pantsbuild/pants/pull/15347)\].
 
-# More efficient remote cache access
+## More efficient remote cache access
 
 We've added new behaviors to our [remote cache support](https://www.pantsbuild.org/docs/remote-caching) which can improve the efficiency and performance by optionally skipping downloads of cache entries where possible.
 
@@ -71,7 +71,7 @@ With the new [`[GLOBAL].cache_content_behavior = "validate"`](https://www.pantsb
 
 Because this can change the behavior of builds when a remote cache is flaky or unavailable, `"validate"` mode remains optional behavior, with the old-style `"fetch"` behavior remaining the default.  \[[#16409](https://github.com/pantsbuild/pants/pull/16409)\]
 
-# Lower barriers to adoption for Python open source projects
+## Lower barriers to adoption for Python open source projects
 
 We're also working towards making it easier to adopt pants in Python projects that use the setuptools or distutils workflows. This release adds support for `setuptools_scm` and `mypyc`.
 
@@ -79,7 +79,7 @@ Pants 2.13 [adds support for the `setuptools_scm` tools](https://www.pantsbuild.
 
 We've also started building out initial support for Python build-time requirements, starting with producing dists that use `mypyc` in their existing `setup.py` file \[[#15380](https://github.com/pantsbuild/pants/pull/15380)\].
 
-# Other notable changes
+## Other notable changes
 
 As always, this release brings a [whole pile of smaller features, improvements, and bugfixes](https://github.com/pantsbuild/pants/blob/2.13.x/src/python/pants/notes/2.13.x.md), including:
 
@@ -106,6 +106,6 @@ Try out one of our example repositories:
 
 And let us know what you think in [Slack!](https://www.pantsbuild.org/docs/getting-help)
 
-# Thanks!
+## Thanks!
 
 Pants wouldn't be possible without everyone who contributed to 2.13, including everyone who shared feedback on changes and who tested release candidates! Thank you all!

--- a/blog/2023-02-24-pants-2-15/index.mdx
+++ b/blog/2023-02-24-pants-2-15/index.mdx
@@ -22,7 +22,7 @@ Along with our usual assortment of new tool support and incremental improvements
 
 You can update by setting `pants_version = "2.15.0"` in your `pants.toml` file. See [upgrade tips](https://www.pantsbuild.org/v2.15/docs/upgrade-tips) for more information.
 
-# Support for easier multi-platform development with Target Environments
+## Support for easier multi-platform development with Target Environments
 
 Pants 2.15's biggest new feature is [Target Environments, unlocking support for workflows that span multiple platforms](https://www.pantsbuild.org/v2.15/docs/environments).
 
@@ -74,13 +74,13 @@ Target Environments represent one of the biggest internal changes to Pants since
 
 To read more about this quite large feature, you can read our in-depth blog post.
 
-# Containerized local development support with the Docker command runner
+## Containerized local development support with the Docker command runner
 
 If you're in an organization that deploys applications in containers, it can often make sense for developers to do their testing and local verification in a containerized environment. In previous versions of Pants, if you wanted to run tools or check behaviors inside a container, you'd need to import your codebase into a container and run Pants itself within the container.
 
 Now, thanks to Target Environments and our new Docker command runner, Pants can use its precise understanding of the files required in your build to run tools, tests, and other processes transparently inside a local Docker container. Just [define a `docker_environment` to define your container's properties](https://www.pantsbuild.org/v2.15/docs/reference-docker_environment), set the `environment` on the parts of your codebase that you want to handle in Docker, and Pants will take care of the rest.
 
-# Stop making linters pass manually, `fix` your code automatically!
+## Stop making linters pass manually, `fix` your code automatically!
 
 Pants supports a wide array of quality checkers that can point out where your code is unsafe, uses deprecated code patterns, or fails documentation standards. Often, running `./pants lint` means being faced with a pile of small, trivial changes to make.
 
@@ -92,19 +92,19 @@ Pants 2.15 lets you run your tools in fixup mode! [Use `./pants fix`](https://ww
 
 We've been using `./pants fix` internally for a few months now, and we've appreciated the time saved from not having to manually fix simple linting errors. Now you can, too!
 
-# OpenAPI support with dependency inference for JVM projects
+## OpenAPI support with dependency inference for JVM projects
 
 Pants 2.15.0 adds [initial support for OpenAPI](https://www.pantsbuild.org/v2.15/docs/reference-openapi_source), along with `./pants tailor` support for OpenAPI schemas, and support for automatically generating JVM bindings based on OpenAPI schemas in your repository.
 
 For JVM users, this means that writing code that depends on bindings generated from an OpenAPI schema is as simple as declaring an `openapi_document` target that depends on your schema and importing the resulting package in your JVM code. Bindings will be automatically built when you build your code, with no need to deploy extra artifacts. When your schema changes, new bindings will automatically be available.
 
-# Describe your codebase better with synthetic targets
+## Describe your codebase better with synthetic targets
 
 Plugins can now programmatically create their own targets, which can be used as dependencies in your `BUILD` files or as goal targets when invoking a Pants command line.
 
 It's early days yet, but in future releases synthetic targets will allow users and plugin authors to better specify the structure of their codebase along with dependencies that can't currently be effectively modeled with Pants.
 
-# Other notable changes
+## Other notable changes
 
 - A plethora of improvements in Go, including access to the `go` binary in tests, `go generate` support, and better lint and `./pants tailor` functionality
 - Formatters and linters can now operate on any file in the project without prior configuration

--- a/blog/2023-03-02-write-or-speak-about-pants-communitys-favorite-topics/index.mdx
+++ b/blog/2023-03-02-write-or-speak-about-pants-communitys-favorite-topics/index.mdx
@@ -56,6 +56,6 @@ Whatever you're doing with PEX, if you find it interesting others probably will 
 
 [SCIE](../2023-02-23-the-pants-launcher-binary-a-much-simpler-way-to-install-and-run-pants/index.mdx) is the latest project from the Pantsbuild team, and we're very excited about its potential. We'd love to see some posts about how you're using SCIE and highlighting its merits for others to tap.
 
-# Public speaking
+## Public speaking
 
 Notice something about all of these topics? They make great topics of a talk too! Whether it's a lunch-time presentation to your team, a meetup talk, lightning/ignite talk, or conference session, these are topics that developers and data scientists appreciate learning more about. Your experience and perspective on any of these topics can be a valued contribution to peers' professional development and productivity. Just like blogging, feel free to reach out for assistance with talk development/prep. We're happy to provide the support you need, upon request — whether that be a sounding board, mentorship, a friendly audience for a rehearsal, or feedback. Here's also a \[running list of open CFPs\], so you can catch relevant speaking opportunities!


### PR DESCRIPTION
This adjusts all blog posts that have multiple `<h1>` headings to instead not have multiple, by bumping those duplicates to `<h2>` (and so on, for any nested headings).

Related to #112, picked out of #117.