### PR TITLE
When syncing, make the a0 release create a new version

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -50,22 +50,7 @@ jobs:
           fetch-depth: 0
           path: pantsbuild.org
 
-      # Calculate destination
-      - name: Calculate destination
-        id: get-destination-dir
-        run: |
-          BASE_VERSION=$(echo "${{ inputs.version }}" | sed -E 's/^([0-9]+)\.([0-9]+)\.\w+.*/\1.\2/')
-          DESTINATION_DIR="versioned_docs/version-$BASE_VERSION"
-          if [ ! -d "pantsbuild.org/$DESTINATION_DIR" ]; then
-            DESTINATION_DIR="docs"
-          fi
-          echo "DESTINATION_DIR=$(echo "$DESTINATION_DIR")" | tee -a "${GITHUB_OUTPUT}"
-      - run: |
-          rm -rf "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
-          mkdir -p "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}/reference"
-          cp help-all.json "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}/reference"
-
-      # Generate reference docs
+      # Setup `node` and friends
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -82,6 +67,31 @@ jobs:
             ${{ runner.os }}-website-
       - run: yarn install --frozen-lockfile
         working-directory: pantsbuild.org
+
+      # Make a new version, if required
+      - name: Make a new version
+        if: endsWith(inputs.version, "a0")
+        run: |
+          BASE_VERSION=$(echo "${{ inputs.version }}" | sed -E 's/^([0-9]+)\.([0-9]+)\.\w+.*/\1.\2/')
+          npm run docusaurus docs:version $BASE_VERSION
+        working-directory: pantsbuild.org
+
+      # Calculate destination
+      - name: Calculate destination
+        id: get-destination-dir
+        run: |
+          BASE_VERSION=$(echo "${{ inputs.version }}" | sed -E 's/^([0-9]+)\.([0-9]+)\.\w+.*/\1.\2/')
+          DESTINATION_DIR="versioned_docs/version-$BASE_VERSION"
+          if [ ! -d "pantsbuild.org/$DESTINATION_DIR" ]; then
+            DESTINATION_DIR="docs"
+          fi
+          echo "DESTINATION_DIR=$(echo "$DESTINATION_DIR")" | tee -a "${GITHUB_OUTPUT}"
+      - run: |
+          rm -rf "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
+          mkdir -p "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}/reference"
+          cp help-all.json "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}/reference"
+
+      # Generate reference docs
       - name: Generate reference docs
         run: npm run generate-reference "${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
         working-directory: pantsbuild.org

--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -73,7 +73,10 @@ jobs:
         if: endsWith(inputs.version, "a0")
         run: |
           BASE_VERSION=$(echo "${{ inputs.version }}" | sed -E 's/^([0-9]+)\.([0-9]+)\.\w+.*/\1.\2/')
-          npm run docusaurus docs:version $BASE_VERSION
+          # Check if the directory already exists, this might be a re-run.
+          if [ ! -d "versioned_docs/version-$BASE_VERSION" ]; then
+            npm run docusaurus docs:version $BASE_VERSION
+          fi
         working-directory: pantsbuild.org
 
       # Calculate destination

--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -68,27 +68,22 @@ jobs:
       - run: yarn install --frozen-lockfile
         working-directory: pantsbuild.org
 
-      # Make a new version, if required
-      - name: Make a new version
-        if: endsWith(inputs.version, "a0")
-        run: |
-          BASE_VERSION=$(echo "${{ inputs.version }}" | sed -E 's/^([0-9]+)\.([0-9]+)\.\w+.*/\1.\2/')
-          # Check if the directory already exists, this might be a re-run.
-          if [ ! -d "versioned_docs/version-$BASE_VERSION" ]; then
-            npm run docusaurus docs:version $BASE_VERSION
-          fi
-        working-directory: pantsbuild.org
-
       # Calculate destination
       - name: Calculate destination
         id: get-destination-dir
         run: |
           BASE_VERSION=$(echo "${{ inputs.version }}" | sed -E 's/^([0-9]+)\.([0-9]+)\.\w+.*/\1.\2/')
           DESTINATION_DIR="versioned_docs/version-$BASE_VERSION"
-          if [ ! -d "pantsbuild.org/$DESTINATION_DIR" ]; then
-            DESTINATION_DIR="docs"
+          if [ ! -d "$DESTINATION_DIR" ]; then
+            if [[ "${{ inputs.version }}" =~ .*\.a0$ ]];
+              # a0 => we've cut a new branch from `main`, so make a new version
+              npm run docusaurus docs:version $BASE_VERSION
+            else
+              DESTINATION_DIR="docs"
+            fi
           fi
           echo "DESTINATION_DIR=$(echo "$DESTINATION_DIR")" | tee -a "${GITHUB_OUTPUT}"
+        working-directory: pantsbuild.org
       - run: |
           rm -rf "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}"
           mkdir -p "pantsbuild.org/${{ steps.get-destination-dir.outputs.DESTINATION_DIR }}/reference"


### PR DESCRIPTION
This change makes it so the `sync_docs` workflow has an extra step that turns `docs/` into `versioned_docs/<version>` if the release is a0.

The following steps should sync the `a0` release into the newly created directory.

This aligns with our release process, where `a0` is a new stable branch: https://www.pantsbuild.org/2.18/docs/contributions/releases/release-process#a0---create-a-new-git-branch