### PR TITLE
add missing `then`

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -75,7 +75,7 @@ jobs:
           BASE_VERSION=$(echo "${{ inputs.version }}" | sed -E 's/^([0-9]+)\.([0-9]+)\.\w+.*/\1.\2/')
           DESTINATION_DIR="versioned_docs/version-$BASE_VERSION"
           if [ ! -d "$DESTINATION_DIR" ]; then
-            if [[ "${{ inputs.version }}" =~ .*\.a0$ ]];
+            if [[ "${{ inputs.version }}" =~ .*\.a0$ ]]; then
               # a0 => we've cut a new branch from `main`, so make a new version
               npm run docusaurus docs:version $BASE_VERSION
             else


### PR DESCRIPTION
The sync-docs action failed for 2.19.0 (https://github.com/pantsbuild/pantsbuild.org/actions/runs/7672731834/job/20913871609) and it looks like this is the issue.