### PR TITLE
Use `help-all.json` to label prereleases in version selector

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -68,8 +68,8 @@ const isPrerelease = (version) => {
     (value) => value["rank"] == "HARDCODED"
   );
 
-  // Check if it's one of xx.xx.xx.dev0, xx.xx.xxa0, xx.xx.xxrc0
-  const rex = /^(\d+\.\d+\.\d+)(\.dev|a|rc)\d+$/;
+	// Check if it's one of xx.xx.xx.dev0, xx.xx.xxa0, xx.xx.xxb0,  xx.xx.xxrc0, etc.
+  const rex = /^(\d+\.\d+\.\d+)(\.dev|a|b|rc)\d+$/;
 
   return rex.test(hardcoded["value"]);
 };

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -312,7 +312,7 @@ const config = {
                 acc[version] = {
                   label:
                     index === 0
-                      ? `${version} (prerelease)`
+                      ? `${version}`
                       : index < 3
                         ? version
                         : `${version} (deprecated)`,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -68,7 +68,7 @@ const isPrerelease = (version) => {
     (value) => value["rank"] == "HARDCODED"
   );
 
-	// Check if it's one of xx.xx.xx.dev0, xx.xx.xxa0, xx.xx.xxb0,  xx.xx.xxrc0, etc.
+  // Check if it's one of xx.xx.xx.dev0, xx.xx.xxa0, xx.xx.xxb0,  xx.xx.xxrc0, etc.
   const rex = /^(\d+\.\d+\.\d+)(\.dev|a|b|rc)\d+$/;
 
   return rex.test(hardcoded["value"]);


### PR DESCRIPTION
This ensures that when we release a version, it'll not tag it as a prerelease.