### PR TITLE
check prerelease for lastVersion

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -327,7 +327,7 @@ const config = {
         routeBasePath: "/",
         disableVersioning,
         onlyIncludeVersions,
-        lastVersion: onlyIncludeVersions ? undefined : versions[1],
+        lastVersion: onlyIncludeVersions ? undefined : versions.find((v) => !isPrerelease(v)),
         versions: {
           current: {
             label: `${currentVersion} (dev)`,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -327,7 +327,9 @@ const config = {
         routeBasePath: "/",
         disableVersioning,
         onlyIncludeVersions,
-        lastVersion: onlyIncludeVersions ? undefined : versions.find((v) => !isPrerelease(v)),
+        lastVersion: onlyIncludeVersions
+          ? undefined
+          : versions.find((v) => !isPrerelease(v)),
         versions: {
           current: {
             label: `${currentVersion} (dev)`,


### PR DESCRIPTION
Noticed that if you go to `pantsbuild.org` in a clean browsing session it'll still go to 2.18, because this defaults to index 1 still. 