### PR TITLE
Fix capitalization of "Terraform" in left menu.

### DIFF
--- a/versioned_docs/version-2.18/docs/terraform/_category_.json
+++ b/versioned_docs/version-2.18/docs/terraform/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "terraform",
+  "label": "Terraform",
   "position": 11
 }

--- a/versioned_docs/version-2.19/docs/terraform/_category_.json
+++ b/versioned_docs/version-2.19/docs/terraform/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "TERRAFORM",
+  "label": "Terraform",
   "position": 11
 }


### PR DESCRIPTION
It is correct in the unversioned docs/docs/terraform/_category_.json,
and doesn't exist prior to 2.18.x.
