### PR TITLE
Fix deprecated version inconsistencies

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -68,8 +68,10 @@ const isPrerelease = (version) => {
     (value) => value["rank"] == "HARDCODED"
   );
 
-  // Check if it's one of xx.xx.xx.dev0, xx.xx.xxa0, xx.xx.xxb0,  xx.xx.xxrc0, etc.
-  const rex = /^(\d+\.\d+\.\d+)(\.dev|a|b|rc)\d+$/;
+  // Check if it's one of xx.xx.0.dev0, xx.xx.0a0, xx.xx.0b0,  xx.xx.0rc0, etc.
+  // We don't treat patch versions pre-releases as pre-releases, since it looks weird.
+  // Optimally we shouldn't sync those either way, but some have ended up here by accident.
+  const rex = /^(\d+\.\d+\.0)(\.dev|a|b|rc)\d+$/;
 
   return rex.test(hardcoded["value"]);
 };
@@ -341,15 +343,15 @@ const config = {
                 acc[version] = {
                   label: isPrerelease(version)
                     ? `${version} (prerelease)`
-                    : index < 3
+                    : index < 2 + (isPrerelease(versions[0]) ? 1 : 0)
                       ? version
                       : `${version} (deprecated)`,
                   banner: isPrerelease(version)
                     ? "unreleased"
-                    : index < 3
+                    : index < 2 + (isPrerelease(versions[0]) ? 1 : 0)
                       ? "none"
                       : "unmaintained",
-                  noIndex: index >= 3,
+                  noIndex: index >= 2 + (isPrerelease(versions[0]) ? 1 : 0),
                   path: version,
                 };
                 return acc;

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -37,10 +37,15 @@ export default function DocsVersionDropdownNavbarItem({
       onClick: () => savePreferredVersionName(version.name),
     };
   });
+
+  // We either show [prerelease, current, previous, deprecated]
+  // or             [current, previous, deprecated]
+  // versions in the dropdown.
+  const sliceCount = versions[1].label.includes("prerelease") ? 5 : 4;
   const items = [
     ...dropdownItemsBefore,
     // !!!!! SIGNPOST: This is the only change from the original code
-    ...versionLinks.slice(1, 5),
+    ...versionLinks.slice(1, sliceCount),
     // !!!!!
     ...dropdownItemsAfter,
   ];


### PR DESCRIPTION
Fixes a few issues:

* We have checked in rc versions for 2.17 and 2.16, which meant they got labeled as pre-release. I opted to only treat `.0` versions as pre-release here to have a sensible lable even if we accidentally sync pre-release docs later
* I also noted that we showed two deprecated versions in the dropdown, we'll now cut off one more item if the first entry is prerelease as showing two deprecated versions seemed excessive
* Also fixed so the unmaintained banner shows up properly
* For consistency I did the same change to `noIndex` field but i've no idea what that does practically. Search indexing? Google? All?
