### PR TITLE
Upload build from PR CI for easier previewing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,13 @@ jobs:
 
       # As an interim step in lieu of https://github.com/pantsbuild/pantsbuild.org/issues/28, upload
       # the build result so someone can download and view it, without having to run the build
-      # themselves.
+      # themselves.  (The explicit zip step is workaround for
+      # https://github.com/actions/upload-artifact/issues/333 )
+      - name: Zip build
+        run: zip -r site-build.zip build/
+
       - name: Upload build
         uses: actions/upload-artifact@v4
         with:
           name: "site-build"
-          path: build
+          path: site-build.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,12 @@ jobs:
         run: npm run build
         env:
           NODE_OPTIONS: --max-old-space-size=6144
+
+      # As an interim step in lieu of https://github.com/pantsbuild/pantsbuild.org/issues/28, upload
+      # the build result so someone can download and view it, without having to run the build
+      # themselves.
+      - name: Upload build
+        uses: actions/upload-artifact@v4
+        with:
+          name: "site-build"
+          path: build


### PR DESCRIPTION
This has PR CI upload the resulting static site output, once the build finishes.

This is a stop gap for https://github.com/pantsbuild/pantsbuild.org/issues/28 that's seems like it's better than nothing: to preview a PR, click through to the build summary, download the artifact and take a look. This saves a reviewer from needing to check-out the branch and build it, just do a (100MB) download instead.