### PR TITLE
Suggest `npm run build` in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ PANTSBUILD_ORG_INCLUDE_VERSIONS=$version1,$version2 npm start
 To build the site, run:
 
 ```bash
-NODE_OPTIONS="--max-old-space-size=6144" npm build
+NODE_OPTIONS="--max-old-space-size=6144" npm run build
 ```
 
 (Note: Node needs more than the default amount of RAM because this site is beefy)


### PR DESCRIPTION
The docs currently suggest `npm build` which doesn't work with npm v8.6.0, which is what my system uses with node 18.