### PR TITLE
Document the need for migrating tool to user lockfiles

### DIFF
--- a/docs/docs/python/overview/lockfiles.mdx
+++ b/docs/docs/python/overview/lockfiles.mdx
@@ -184,6 +184,9 @@ It is strongly recommended that these tools be installed from a hermetic lockfil
 
 The only time you need to think about this is if you want to customize the tool requirements that Pants uses. This might be the case if you want to modify the version of a tool or add extra requirements (for example, tool plugins).
 
+:::caution Exporting tools requires a custom lockfile
+:::
+
 If you want a tool to be installed from some resolve, instead of from the built-in lockfile, you set `install_from_resolve` and `requirements` on the tool's config section:
 
 ```toml title="pants.toml"

--- a/docs/docs/using-pants/setting-up-an-ide.mdx
+++ b/docs/docs/using-pants/setting-up-an-ide.mdx
@@ -49,7 +49,7 @@ The `--py-resolve-format=symlinked_immutable_virtualenv` option symlinks to an i
 
 ### Tool virtualenvs
 
-`pants export` can also create a virtualenv for each of the Python tools you use via Pants, such as `black`, `isort`, `pytest`, `mypy`, `flake8` and so on (you can run `/pants help tools` to get a list of the tools Pants uses). Use the tool name as the resolve name argument to the `--resolve` flag. This allows you to configure your editor to use the same version of the tool as Pants does for workflows like formatting on save.
+`pants export` can also create a virtualenv for each of the Python tools you use via Pants, such as `black`, `isort`, `pytest`, `mypy`, `flake8` and so on. This allows you to configure your editor to use the same version of the tool as Pants does for workflows like formatting on save. Follow the instructions for creating a tool lockfile  [here](../../python/overview/lockfiles#lockfiles-for-tools).
 
 ## Generated code
 

--- a/docs/reference/goals/export.mdx
+++ b/docs/reference/goals/export.mdx
@@ -15,6 +15,10 @@ pants export [args]
 
 Export Pants data for use in other tools, such as IDEs.
 
+:::caution Exporting tools requires creating a custom lockfile for them
+Follow the instructions for creating tool lockfiles [here](../../docs/python/overview/lockfiles#lockfiles-for-tools)
+:::
+
 Backend: <span className="color--primary">`pants.core`</span>
 
 Config section: <span className="color--primary">`[export]`</span>

--- a/versioned_docs/version-2.18/docs/python/overview/lockfiles.mdx
+++ b/versioned_docs/version-2.18/docs/python/overview/lockfiles.mdx
@@ -184,6 +184,9 @@ It is strongly recommended that these tools be installed from a hermetic lockfil
 
 The only time you need to think about this is if you want to customize the tool requirements that Pants uses. This might be the case if you want to modify the version of a tool or add extra requirements (for example, tool plugins).
 
+:::caution Exporting tools requires a custom lockfile
+:::
+
 If you want a tool to be installed from some resolve, instead of from the built-in lockfile, you set `install_from_resolve` and `requirements` on the tool's config section:
 
 ```toml title="pants.toml"

--- a/versioned_docs/version-2.18/docs/using-pants/setting-up-an-ide.mdx
+++ b/versioned_docs/version-2.18/docs/using-pants/setting-up-an-ide.mdx
@@ -49,7 +49,7 @@ The `--py-resolve-format=symlinked_immutable_virtualenv` option symlinks to an i
 
 ### Tool virtualenvs
 
-`pants export` can also create a virtualenv for each of the Python tools you use via Pants, such as `black`, `isort`, `pytest`, `mypy`, `flake8` and so on (you can run `/pants help tools` to get a list of the tools Pants uses). Use the tool name as the resolve name argument to the `--resolve` flag. This allows you to configure your editor to use the same version of the tool as Pants does for workflows like formatting on save.
+`pants export` can also create a virtualenv for each of the Python tools you use via Pants, such as `black`, `isort`, `pytest`, `mypy`, `flake8` and so on. This allows you to configure your editor to use the same version of the tool as Pants does for workflows like formatting on save. Follow the instructions for creating a tool lockfile  [here](../../python/overview/lockfiles#lockfiles-for-tools).
 
 ## Generated code
 

--- a/versioned_docs/version-2.18/reference/goals/export.mdx
+++ b/versioned_docs/version-2.18/reference/goals/export.mdx
@@ -15,6 +15,10 @@ pants export [args]
 
 Export Pants data for use in other tools, such as IDEs.
 
+:::caution Exporting tools requires creating a custom lockfile for them
+Follow the instructions for creating tool lockfiles [here](../../docs/python/overview/lockfiles#lockfiles-for-tools)
+:::
+
 Backend: <span className="color--primary">`pants.core`</span>
 
 Config section: <span className="color--primary">`[export]`</span>

--- a/versioned_docs/version-2.19/docs/python/overview/lockfiles.mdx
+++ b/versioned_docs/version-2.19/docs/python/overview/lockfiles.mdx
@@ -184,6 +184,9 @@ It is strongly recommended that these tools be installed from a hermetic lockfil
 
 The only time you need to think about this is if you want to customize the tool requirements that Pants uses. This might be the case if you want to modify the version of a tool or add extra requirements (for example, tool plugins).
 
+:::caution Exporting tools requires a custom lockfile
+:::
+
 If you want a tool to be installed from some resolve, instead of from the built-in lockfile, you set `install_from_resolve` and `requirements` on the tool's config section:
 
 ```toml title="pants.toml"

--- a/versioned_docs/version-2.19/docs/using-pants/setting-up-an-ide.mdx
+++ b/versioned_docs/version-2.19/docs/using-pants/setting-up-an-ide.mdx
@@ -49,7 +49,7 @@ The `--py-resolve-format=symlinked_immutable_virtualenv` option symlinks to an i
 
 ### Tool virtualenvs
 
-`pants export` can also create a virtualenv for each of the Python tools you use via Pants, such as `black`, `isort`, `pytest`, `mypy`, `flake8` and so on (you can run `/pants help tools` to get a list of the tools Pants uses). Use the tool name as the resolve name argument to the `--resolve` flag. This allows you to configure your editor to use the same version of the tool as Pants does for workflows like formatting on save.
+`pants export` can also create a virtualenv for each of the Python tools you use via Pants, such as `black`, `isort`, `pytest`, `mypy`, `flake8` and so on. This allows you to configure your editor to use the same version of the tool as Pants does for workflows like formatting on save. Follow the instructions for creating a tool lockfile  [here](../../python/overview/lockfiles#lockfiles-for-tools).
 
 ## Generated code
 

--- a/versioned_docs/version-2.19/reference/goals/export.mdx
+++ b/versioned_docs/version-2.19/reference/goals/export.mdx
@@ -15,6 +15,10 @@ pants export [args]
 
 Export Pants data for use in other tools, such as IDEs.
 
+:::caution Exporting tools requires creating a custom lockfile for them
+Follow the instructions for creating tool lockfiles [here](../../docs/python/overview/lockfiles#lockfiles-for-tools)
+:::
+
 Backend: <span className="color--primary">`pants.core`</span>
 
 Config section: <span className="color--primary">`[export]`</span>


### PR DESCRIPTION
We did some refactoring and the old steps no longer worked. It's come up a few times. We can be helpful and provide the info everywhere. Also we didn't update the steps for setting up IDEs.