### PR TITLE
Add link to "Getting Help" to footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -271,6 +271,10 @@ const config = {
           title: "Community",
           items: [
             {
+              label: "Getting Help",
+              href: "/community/getting-help",
+            },
+            {
               label: "Members",
               href: "/community/members",
             },


### PR DESCRIPTION
https://www.pantsbuild.org/community/getting-help seems to currently only be linked from the synced docs/reference, but might be nice to have in the footer too?

![image](https://github.com/pantsbuild/pantsbuild.org/assets/1203825/f17e0837-a8e1-4a51-9f94-6ebd0b31a82d)
