### PR TITLE
Check for .0a0 for new version creation, not .a0

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -75,7 +75,7 @@ jobs:
           BASE_VERSION=$(echo "${{ inputs.version }}" | sed -E 's/^([0-9]+)\.([0-9]+)\.\w+.*/\1.\2/')
           DESTINATION_DIR="versioned_docs/version-$BASE_VERSION"
           if [ ! -d "$DESTINATION_DIR" ]; then
-            if [[ "${{ inputs.version }}" =~ .*\.a0$ ]]; then
+            if [[ "${{ inputs.version }}" =~ .*\.0a0$ ]]; then
               # a0 => we've cut a new branch from `main`, so make a new version
               npm run docusaurus docs:version $BASE_VERSION
             else


### PR DESCRIPTION
Minor typo in the check for alpha versions meant it didn't trigger: it's intending to search for `2.x.0a0`, i.e. first alpha version leading up to the first stable release in `2.x` series... but missed the 0 between the `.` and the `a`.

This explains (https://github.com/pantsbuild/pantsbuild.org/pull/162#issuecomment-1968056882): why we don't have a `versioned_docs/version-2.20` directory despite #153  landing.

This PR doesn't create that directory, just fixing the bug in the automation. I've retriggered the sync from this PR's branch to do that: #164