### PR TITLE
Replace front-page "learn more" link with hard-coded 2.19 one

### DIFF
--- a/src/pages/_index.mdx
+++ b/src/pages/_index.mdx
@@ -116,7 +116,7 @@ You'll find no subsets like Starlark here. Pants empowers you with full support 
 
 Pants supports Python, Docker, Go, Java, Kotlin, Pex, Protodoc, Scala, Shell, Thrift, Protobuf,
 Docker, Helm, many linting and formatting tools, packaging, coverage, and more.
-[Learn more.](/docs/introduction/welcome-to-pants)
+[Learn more.](/2.19/docs/introduction/welcome-to-pants)
 
 </div>
 </div>


### PR DESCRIPTION
This papers over the dead "Learn more" link on the pantsbuild.org front page (https://github.com/pantsbuild/pants/issues/20648) by replacing it with the hard-coded `/2.19/docs/introduction/welcome-to-pants`, for the current latest-stable version.

This isn't a full solution: preferably this would be a "dynamic" link, pointing to the latest stable version. Thus this doesn't close that issue.

The dynamic approach we take in some other pages isn't perfect because it isn't to the latest _stable_ release, but can include pre-releases (it [currently](https://www.pantsbuild.org/community/members#how-can-i-contribute-to-pants) points to `/2.20/...`, which is probably reasonable for a contributing guide, but less so for a "getting started" one): https://github.com/pantsbuild/pantsbuild.org/blob/ac1d7051581bf4be77abd95b0405aa97202e6aad/src/pages/community/members.mdx#L28