### PR TITLE
Centralise versioning configuration

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,7 +57,7 @@ const getFullVersion = (shortVersion) => {
   return hardcoded["value"];
 };
 
-const isPrerelease = (shortVersion) => {
+const isPrereleaseVersion = (shortVersion) => {
   // Check if it's one of xx.xx.0.dev0, xx.xx.0a0, xx.xx.0b0,  xx.xx.0rc0, etc.
   // We don't treat patch versions pre-releases as pre-releases, since it looks weird.
   // Optimally we shouldn't sync those either way, but some have ended up here by accident.
@@ -344,7 +344,7 @@ const config = {
         onlyIncludeVersions,
         lastVersion: onlyIncludeVersions
           ? undefined
-          : versions.find((v) => !isPrerelease(v)),
+          : versions.find((v) => !isPrereleaseVersion(v)),
         versions: {
           current: {
             label: `${currentVersion} (dev)`,
@@ -354,17 +354,18 @@ const config = {
             ? {}
             : versions.reduce((acc, version, index) => {
                 acc[version] = {
-                  label: isPrerelease(version)
+                  label: isPrereleaseVersion(version)
                     ? `${version} (prerelease)`
-                    : index < 2 + (isPrerelease(versions[0]) ? 1 : 0)
+                    : index < 2 + (isPrereleaseVersion(versions[0]) ? 1 : 0)
                       ? version
                       : `${version} (deprecated)`,
-                  banner: isPrerelease(version)
+                  banner: isPrereleaseVersion(version)
                     ? "unreleased"
-                    : index < 2 + (isPrerelease(versions[0]) ? 1 : 0)
+                    : index < 2 + (isPrereleaseVersion(versions[0]) ? 1 : 0)
                       ? "none"
                       : "unmaintained",
-                  noIndex: index >= 2 + (isPrerelease(versions[0]) ? 1 : 0),
+                  noIndex:
+                    index >= 2 + (isPrereleaseVersion(versions[0]) ? 1 : 0),
                   path: version,
                 };
                 return acc;

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,18 +11,14 @@ import { themes as prismThemes } from "prism-react-renderer";
 const organizationName = "pantsbuild";
 const projectName = "pantsbuild.org";
 
-function getCurrentVersion() {
-  const lastReleasedVersion = versions[0];
-  const version = parseInt(lastReleasedVersion.replace("2.", ""), 10);
-  return `2.${version + 1}`;
-}
-
 // Controls for how much to build:
 //  - (No env vars set) -> Just uses the docs from `/docs/` (Docusaurus calls this "current version"), and no blog.
 //  - PANTSBUILD_ORG_INCLUDE_VERSIONS=<version>,<version> -> Use current version and versions specified
 //  - PANTSBUILD_ORG_INCLUDE_BLOG=1 -> Include the blog.
 // Note that `NODE_ENV === 'production' builds _everything_.
 const isDev = process.env.NODE_ENV === "development";
+
+// Versions
 const disableVersioning =
   isDev && process.env.PANTSBUILD_ORG_INCLUDE_VERSIONS === undefined;
 const onlyIncludeVersions = isDev
@@ -32,23 +28,13 @@ const onlyIncludeVersions = isDev
       )
     : ["current"]
   : undefined;
+
+function getCurrentVersion() {
+  const lastReleasedVersion = versions[0];
+  const version = parseInt(lastReleasedVersion.replace("2.", ""), 10);
+  return `2.${version + 1}`;
+}
 const currentVersion = getCurrentVersion();
-const includeBlog = process.env.PANTSBUILD_ORG_INCLUDE_BLOG === "1" || !isDev;
-
-const formatCopyright = () => {
-  const makeLink = (href, text) => `<a href="${href}">${text}</a>`;
-
-  const repoUrl = `https://github.com/${organizationName}/${projectName}`;
-  const repoLink = makeLink(repoUrl, "Website source");
-
-  // Only set by CI, so fallback to just `local` for local dev
-  const docsCommit = process.env.GITHUB_SHA;
-  const commitLink = docsCommit
-    ? makeLink(`${repoUrl}/commit/${docsCommit}`, docsCommit.slice(0, 6))
-    : "local";
-
-  return `Copyright © Pants project contributors. ${repoLink} @ ${commitLink}.`;
-};
 
 const isPrerelease = (version) => {
   const reference_dir = path.join(
@@ -74,6 +60,25 @@ const isPrerelease = (version) => {
   const rex = /^(\d+\.\d+\.0)(\.dev|a|b|rc)\d+$/;
 
   return rex.test(hardcoded["value"]);
+};
+
+// Blog
+const includeBlog = process.env.PANTSBUILD_ORG_INCLUDE_BLOG === "1" || !isDev;
+
+// Other information
+const formatCopyright = () => {
+  const makeLink = (href, text) => `<a href="${href}">${text}</a>`;
+
+  const repoUrl = `https://github.com/${organizationName}/${projectName}`;
+  const repoLink = makeLink(repoUrl, "Website source");
+
+  // Only set by CI, so fallback to just `local` for local dev
+  const docsCommit = process.env.GITHUB_SHA;
+  const commitLink = docsCommit
+    ? makeLink(`${repoUrl}/commit/${docsCommit}`, docsCommit.slice(0, 6))
+    : "local";
+
+  return `Copyright © Pants project contributors. ${repoLink} @ ${commitLink}.`;
 };
 
 const config = {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -34,16 +34,16 @@ function getCurrentVersion() {
   const version = parseInt(lastReleasedVersion.replace("2.", ""), 10);
   return `2.${version + 1}`;
 }
+
 const currentVersion = getCurrentVersion();
 
-const isPrerelease = (version) => {
-  const reference_dir = path.join(
-    "versioned_docs",
-    `version-${version}`,
-    "reference"
-  );
+const getFullVersion = (shortVersion) => {
+  const parentDir =
+    shortVersion === currentVersion
+      ? "docs"
+      : path.join("versioned_docs", `version-${shortVersion}`);
   const helpAll = JSON.parse(
-    fs.readFileSync(path.join(reference_dir, "help-all.json"), "utf8")
+    fs.readFileSync(path.join(parentDir, "reference", "help-all.json"), "utf8")
   );
 
   const pantsVersion = helpAll["scope_to_help_info"][""]["advanced"].find(
@@ -54,12 +54,16 @@ const isPrerelease = (version) => {
     (value) => value["rank"] == "HARDCODED"
   );
 
+  return hardcoded["value"];
+};
+
+const isPrerelease = (shortVersion) => {
   // Check if it's one of xx.xx.0.dev0, xx.xx.0a0, xx.xx.0b0,  xx.xx.0rc0, etc.
   // We don't treat patch versions pre-releases as pre-releases, since it looks weird.
   // Optimally we shouldn't sync those either way, but some have ended up here by accident.
   const rex = /^(\d+\.\d+\.0)(\.dev|a|b|rc)\d+$/;
 
-  return rex.test(hardcoded["value"]);
+  return rex.test(getFullVersion(shortVersion));
 };
 
 // Blog

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,8 +21,6 @@ const numberOfSupportedStableVersions = 2;
 const isDev = process.env.NODE_ENV === "development";
 
 // Versions
-const disableVersioning =
-  isDev && process.env.PANTSBUILD_ORG_INCLUDE_VERSIONS === undefined;
 const onlyIncludeVersions = isDev
   ? process.env.PANTSBUILD_ORG_INCLUDE_VERSIONS
     ? ["current"].concat(
@@ -414,7 +412,6 @@ const config = {
       {
         sidebarPath: require.resolve("./sidebars.js"),
         routeBasePath: "/",
-        disableVersioning,
         onlyIncludeVersions,
         lastVersion: onlyIncludeVersions
           ? undefined


### PR DESCRIPTION
The goal here is to centralise the logic around versions, creating a list of all the details about each version (e.g. full version number, whether it's a pre-release or unmaintained etc.), that downstream processing can reference directly rather than recompute. This, for instance, eliminates the duplicated logic around which versions are maintained.

The goal here is to make changes like #174 (and maybe #159) easier. This PR doesn't/shouldn't change observable behaviour.

This also removes the explicit `disableVersioning` flag, since that seems to require changing the contents of the `versions` map. Instead the existing use of `onlyIncludeVersions` seems to do what's intended: make dev builds faster. An `npm start` build takes about 10s both with the old `disableVersioning` setting, or just relying on `onlyIncludeVersions`.

This includes some cut-and-paste rearrangement too that makes the diff harder to understand. The commits are individually reviewable.