### PR TITLE
Invoke pants help-all twice, not thrice

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -28,10 +28,8 @@ jobs:
       - name: Generate help JSON
         # First run `help-all` which will contain the list of every backend in the `name_to_backend_help_info` object,
         # then run it again with every backend enabled.
-        # NB: We run the command initially twice, since the first run might put extraneous crap on stdout.
         run: |
           touch pants.toml
-          PANTS_VERSION="${{ inputs.version }}" pants help-all > /dev/null
           PANTS_VERSION="${{ inputs.version }}" pants help-all > help-all.json
           PANTS_VERSION="${{ inputs.version }}" pants --backend-packages=[$(jq -r '.name_to_backend_help_info | keys_unsorted | map("\"" + . + "\"") | join(",")' help-all.json)] help-all > help-all.json
 


### PR DESCRIPTION
https://github.com/pantsbuild/pants/issues/20315 is now fixed (in https://github.com/pantsbuild/scie-pants/pull/375 / https://github.com/pantsbuild/scie-pants/releases/tag/v0.10.8), so the sync_docs workflow can be slightly slicker.