### PR TITLE
Increase --max-old-space-size option for 2.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          NODE_OPTIONS: --max-old-space-size=8192
+          NODE_OPTIONS: --max-old-space-size=12288
 
       # As an interim step in lieu of https://github.com/pantsbuild/pantsbuild.org/issues/28, upload
       # the build result so someone can download and view it, without having to run the build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          NODE_OPTIONS: --max-old-space-size=6144
+          NODE_OPTIONS: --max-old-space-size=8192
 
       # As an interim step in lieu of https://github.com/pantsbuild/pantsbuild.org/issues/28, upload
       # the build result so someone can download and view it, without having to run the build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: npm run build
         env:
-          NODE_OPTIONS: --max-old-space-size=8192
+          NODE_OPTIONS: --max-old-space-size=12288
 
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: npm run build
         env:
-          NODE_OPTIONS: --max-old-space-size=6144
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ PANTSBUILD_ORG_INCLUDE_VERSIONS=$version1,$version2 npm start
 To build the site, run:
 
 ```bash
-NODE_OPTIONS="--max-old-space-size=6144" npm run build
+NODE_OPTIONS="--max-old-space-size=8192" npm run build
 ```
 
 (Note: Node needs more than the default amount of RAM because this site is beefy)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ PANTSBUILD_ORG_INCLUDE_VERSIONS=$version1,$version2 npm start
 To build the site, run:
 
 ```bash
-NODE_OPTIONS="--max-old-space-size=8192" npm run build
+NODE_OPTIONS="--max-old-space-size=12288" npm run build
 ```
 
 (Note: Node needs more than the default amount of RAM because this site is beefy)


### PR DESCRIPTION
It appears that we need more memory to build after branching for 2.21: the update that splits it (#193) is failing due to running out of memory.

This bumps to 12GiB, slightly less than the runner's RAM (16GB).

(#196 validates that this does actually fix it for 2.21.)