### PR TITLE
Fix dead changelog links in blog posts

### DIFF
--- a/blog/2021-05-20-introducing-pants-2-5/index.mdx
+++ b/blog/2021-05-20-introducing-pants-2-5/index.mdx
@@ -99,7 +99,7 @@ This change means that when you update your `requirements.txt` or `constraints.t
 - `python_tests` targets have a new field `extra_env_vars` to augment the option `[test].extra_env_vars`.
 - Added `RuleRunner.write_files()` for more declarative tests of Pants plugins.
 
-See the full [changelog](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.5.x.md) for more changes.
+See the full [changelog](https://github.com/pantsbuild/pants/blob/release_2.5.0/src/python/pants/notes/2.5.x.md) for more changes.
 
 ## Upcoming in Pants 2.6
 

--- a/blog/2021-08-02-introducing-pants-2-6/index.mdx
+++ b/blog/2021-08-02-introducing-pants-2-6/index.mdx
@@ -59,7 +59,7 @@ You can also now use [MyPy's report generation](https://mypy.readthedocs.io/en/s
 - When there's an exception, we now suggest several other things you can try, like running with `-ldebug`.
 - New `--no-watch-filesystem` option, which allows you to run x86 Docker images from Apple Silicon machines.
 
-See the full [changelog](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.6.x.md) for more changes.
+See the full [changelog](https://github.com/pantsbuild/pants/blob/release_2.6.0/src/python/pants/notes/2.6.x.md) for more changes.
 
 ### **Upcoming in Pants 2.7**
 

--- a/blog/2021-09-27-introducing-pants-2-7/index.mdx
+++ b/blog/2021-09-27-introducing-pants-2-7/index.mdx
@@ -134,7 +134,7 @@ Likewise, you could set up Pants to run only part of your test suite, and then u
 - ASDF support was added to `[python-setup].interpreter_search_paths`.
 - Pants now uses PEP 561, meaning that plugin authors will benefit from type hints.
 
-See the full [changelog](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.7.x.md) for more changes.
+See the full [changelog](https://github.com/pantsbuild/pants/blob/release_2.7.0/src/python/pants/notes/2.7.x.md) for more changes.
 
 ## Upcoming in Pants 2.8
 

--- a/blog/2021-11-17-introducing-pants-2-8/index.mdx
+++ b/blog/2021-11-17-introducing-pants-2-8/index.mdx
@@ -163,7 +163,7 @@ green = "fmt lint check"
 - Added `./pants help tools` to list all tools installed by Pants, including their versions.
 - `typecheck` is deprecated in favor of `check`, which will run MyPy and compilation for languages like Go and Java.
 
-See the full [changelog](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.8.x.md) for more changes.
+See the full [changelog](https://github.com/pantsbuild/pants/blob/release_2.8.0/src/python/pants/notes/2.8.x.md) for more changes.
 
 ## Upcoming in Pants 2.9
 

--- a/blog/2022-03-23-introducing-pants-2-10/index.mdx
+++ b/blog/2022-03-23-introducing-pants-2-10/index.mdx
@@ -128,7 +128,7 @@ Thank you to our Go users for this valuable [feedback](https://www.pantsbuild.or
 - Memory usage was reduced by ~30% in most cases.
 - By default, Pants now recognizes the file `<build root>/.pants.rc` to have repo-specific config overrides.
 
-See the full [changelog](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.10.x.md) for more changes, along with our [Plugin Upgrade Guide](https://www.pantsbuild.org/docs/plugin-upgrade-guide).
+See the full [changelog](https://github.com/pantsbuild/pants/blob/release_2.10.0/src/python/pants/notes/2.10.x.md) for more changes, along with our [Plugin Upgrade Guide](https://www.pantsbuild.org/docs/plugin-upgrade-guide).
 
 \-\-
 

--- a/blog/2022-05-02-introducing-pants-2-11/index.mdx
+++ b/blog/2022-05-02-introducing-pants-2-11/index.mdx
@@ -168,7 +168,7 @@ Collectively, some `2.11.x` testers observed a 30-40% speedup for warm (fully ca
 - Pants no longer defaults to your code working with Python 3.6 (`[python].interpreter_constraints`).
 - New `build_file_dir()` symbol in BUILD files.
 
-See the full [changelog](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.11.x.md) for more changes, along with our [plugin upgrade guide](https://www.pantsbuild.org/docs/plugin-upgrade-guide).
+See the full [changelog](https://github.com/pantsbuild/pants/blob/release_2.11.0/src/python/pants/notes/2.11.x.md) for more changes, along with our [plugin upgrade guide](https://www.pantsbuild.org/docs/plugin-upgrade-guide).
 
 ---
 

--- a/blog/2022-09-01-introducing-pants-2-13/index.mdx
+++ b/blog/2022-09-01-introducing-pants-2-13/index.mdx
@@ -91,7 +91,7 @@ As always, this release brings a [whole pile of smaller features, improvements, 
 - Added the option `lint --skip-formatters` to avoid running formatters like Black and Scalafmt in check-only mode. \[[#15427](https://github.com/pantsbuild/pants/pull/15427)\]
 - Improved error messages for invalid target addresses. \[[#15751](https://github.com/pantsbuild/pants/pull/15751)\]
 
-See the full [changelog](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.13.x.md) for more changes, along with our [plugin upgrade guide](https://www.pantsbuild.org/docs/plugin-upgrade-guide).
+See the full [changelog](https://github.com/pantsbuild/pants/blob/release_2.13.0/src/python/pants/notes/2.13.x.md) for more changes, along with our [plugin upgrade guide](https://www.pantsbuild.org/docs/plugin-upgrade-guide).
 
 ---
 

--- a/blog/2023-02-24-pants-2-15/index.mdx
+++ b/blog/2023-02-24-pants-2-15/index.mdx
@@ -113,7 +113,7 @@ It's early days yet, but in future releases synthetic targets will allow users a
 
 We also recently released the new self-contained Pants launcher, which allows you to run Pants without needing to install a compatible Python installation first. It works with previous versions of Pants, as early as 2.12.
 
-See the full [changelog](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.15.x.md) for more changes, along with our [plugin upgrade guide](https://www.pantsbuild.org/docs/plugin-upgrade-guide).
+See the full [changelog](https://github.com/pantsbuild/pants/blob/release_2.15.0/src/python/pants/notes/2.15.x.md) for more changes, along with our [plugin upgrade guide](https://www.pantsbuild.org/docs/plugin-upgrade-guide).
 
 ---
 

--- a/blog/2023-06-16-pants-2-16-0/index.mdx
+++ b/blog/2023-06-16-pants-2-16-0/index.mdx
@@ -92,7 +92,7 @@ The main change is that Pants will now compile Go SDK packages from scratch and 
 - the `generate-lockfiles` goal was extended with the [`--diff`](https://www.pantsbuild.org/v2.16/docs/reference-generate-lockfiles#diff) flag that reports a summary of changes to requirements made after generating the lockfile.
 - the special Python "tool lockfile" functionality is deprecated. It is now possible to use regular "user lockfiles" to provide custom versions of tools.
 
-See the full [changelog](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.16.x.md) for more changes, along with our [plugin upgrade guide](https://www.pantsbuild.org/docs/plugin-upgrade-guide).
+See the full [changelog](https://github.com/pantsbuild/pants/blob/release_2.16.0/src/python/pants/notes/2.16.x.md) for more changes, along with our [plugin upgrade guide](https://www.pantsbuild.org/docs/plugin-upgrade-guide).
 
 ---
 

--- a/blog/2023-08-30-pants-2-17-0-is-released/index.mdx
+++ b/blog/2023-08-30-pants-2-17-0-is-released/index.mdx
@@ -55,7 +55,7 @@ helloworld/translator/translator.py:lib
 
 - More features have been added in the work-in-progress JavaScript backend: there's support for `yarn@v1` and `Node.js` subpath imports as well as the `pnpm` package manager. There's also a new [example-javascript](https://github.com/pantsbuild/example-javascript) repository that you can use to explore JavaScript support in Pants. The Pants maintainers would appreciate any feedback from the community to help guide our JavaScript related development efforts.
 
-See the full [changelog](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.17.x.md) for more changes, along with our [plugin upgrade guide](https://www.pantsbuild.org/docs/plugin-upgrade-guide).
+See the full [changelog](https://github.com/pantsbuild/pants/blob/release_2.17.0/src/python/pants/notes/2.17.x.md) for more changes, along with our [plugin upgrade guide](https://www.pantsbuild.org/docs/plugin-upgrade-guide).
 
 ---
 


### PR DESCRIPTION
Not sure if anything here is generated, but didn't look like it. I couldn't find a perfect tag that followed the minor so I went with the release one. Maybe you want them to target the latest patch for each, but I also assume most/all of these will not be updated anymore anyways.