### PR TITLE
Blog: fix wrong GitHub handle

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -31,8 +31,8 @@ chrisjrn:
 clement:
   name: Clément Hurlin
   title: Director of Engineering at Tweag
-  url: https://github.com/clemen
-  image_url: https://github.com/clemen.png
+  url: https://github.com/smelc
+  image_url: https://github.com/smelc.png
 eric:
   name: Eric Arellano
   title: Pants Maintainer


### PR DESCRIPTION
In the blogpost I authored last year, the link to my GitHub handle is wrong:

![image](https://github.com/pantsbuild/pantsbuild.org/assets/634720/9a9dc32c-9971-43a7-bfd3-9b0047c7f0b3)

So this PR corrects that :slightly_smiling_face: 