### PR TITLE
Fix `main` branch links to changelogs, in blog posts

### DIFF
--- a/blog/2021-09-27-introducing-pants-2-7/index.mdx
+++ b/blog/2021-09-27-introducing-pants-2-7/index.mdx
@@ -140,7 +140,7 @@ See the full [changelog](https://github.com/pantsbuild/pants/blob/release_2.7.0/
 
 We've been working on adding support for other languages, starting with Go and Java. We hope to have made enough meaningful progress for alpha/beta testing.
 
-Other upcoming improvements in Pants [2.8](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.8.x.md):
+Other upcoming improvements in Pants [2.8](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.8.x.md):
 
 - TOML dictionaries will work for `dict` options.
 - Google Cloud Functions, similar to the [AWS Lambda support](https://www.pantsbuild.org/v2.7/docs/awslambda-python).

--- a/blog/2022-06-29-pants-2-12/index.mdx
+++ b/blog/2022-06-29-pants-2-12/index.mdx
@@ -41,7 +41,7 @@ In Pants 2.12, the [interpreter_constraints](https://www.pantsbuild.org/v2.12/do
 
 ## Other notable changes
 
-There are a [long list of additional changes in 2.12](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.12.x.md), but highlights include:
+There are a [long list of additional changes in 2.12](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.12.x.md), but highlights include:
 
 - Adding support for restricting specific Python requirements to consuming only wheels or only sdists. ([details](https://github.com/pantsbuild/pants/pull/14985))
 - After lots of stabilization work, the [default lockfile generator](https://www.pantsbuild.org/v2.12/docs/reference-python#section-lockfile-generator) is now [Pex](https://pex.readthedocs.io/en/latest/). Pex lockfiles bring improved performance when consuming many different subsets of a large resolve, and improved compatibility with `pip` features.

--- a/blog/2022-10-26-pants-2-14/index.mdx
+++ b/blog/2022-10-26-pants-2-14/index.mdx
@@ -95,7 +95,7 @@ If you hadn't already enabled `BUILD` file formatting, you can do so by enabling
 
 ## Other notable changes
 
-There are [a long list of additional changes in 2.14](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.14.x.md), but highlights include:
+There are [a long list of additional changes in 2.14](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.14.x.md), but highlights include:
 
 - [`mypy`'s incremental cache will now be used](https://github.com/pantsbuild/pants/pull/16290), which should significantly reduce the latency of typechecking.
 - Concurrent execution of Python test _methods_ is now [natively supported](https://www.pantsbuild.org/v2.14/docs/python-test-goal#pytest-version-and-plugins) via `pytest-xdist`! If your test methods are concurrency safe, you can set `[pytest].xdist_enabled = True` to run individual test methods concurrently, in addition to Pants' usual file-level parallelism.


### PR DESCRIPTION
This rewrites the old `src/python/pants/notes` path for changelogs to `docs/notes` in three blog posts.

Fixes #209  (together with #222)

There's still some references to the ``src/python/pants/notes`` path in this repo, but I don't think they need updating. They either:

- have a branch or tag reference that has the notes in the old location, e.g. https://github.com/pantsbuild/pantsbuild.org/blob/67038eb6956fe4c8fc956884897efebac6e8fd8d/blog/2023-11-14-pants-2.18.0-is-released/index.mdx#L99
- are in old reference docs, and seems like it can be adequately handled via the redirects we now have: https://github.com/pantsbuild/pants/pull/20937 (alternatively, we _could_ rewrite them)