### PR TITLE
Escape $'s in reference default values 

### DIFF
--- a/docs/reference/global-options.mdx
+++ b/docs/reference/global-options.mdx
@@ -516,7 +516,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -654,7 +654,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/docs/reference/subsystems/jvm.mdx
+++ b/docs/reference/subsystems/jvm.mdx
@@ -70,7 +70,7 @@ deploy_jar_exclude_files = [
     '<str>',
     ...,
 ]`}
-  default_repr={`[\n  "^META-INF/[^/]+\\.SF$",\n  "^META-INF/[^/]+\\.DSA$",\n  "^META-INF/[^/]+\\.RSA$",\n  "META-INF/INDEX.LIST$"\n]`}
+  default_repr={`[\n  "^META-INF/[^/]+\\.SF\$",\n  "^META-INF/[^/]+\\.DSA\$",\n  "^META-INF/[^/]+\\.RSA\$",\n  "META-INF/INDEX.LIST\$"\n]`}
 >
 
 A list of patterns to exclude from all deploy jars. An individual deploy_jar target can also exclude other files, in addition to these, by setting its `exclude_files` field.

--- a/docs/reference/targets/vcs_version.mdx
+++ b/docs/reference/targets/vcs_version.mdx
@@ -91,7 +91,7 @@ All dependencies must share the same value for their `resolve` field.
 
 <Field
     type_repr={`str | None`}
-    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$'`}
+    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?\$'`}
 >
 
 A Python regex string to extract the version string from a VCS tag.

--- a/reference_codegen/generate.mjs
+++ b/reference_codegen/generate.mjs
@@ -89,9 +89,14 @@ function convertDefault(val, type) {
     val = String(val).replace(/\\n/g, "\\\\n");
   }
 
-  return val
-    .replace(buildroot, "<buildroot>")
-    .replace(cachedir, "$XDG_CACHE_HOME");
+  return (
+    val
+      .replace(buildroot, "<buildroot>")
+      .replace(cachedir, "$XDG_CACHE_HOME")
+      // this ends up in a template literal, so if it contains literally ${something} we need to
+      // ensure that doesn't get interpreted as a substitution
+      .replace(/\$/g, "\\$")
+  );
 }
 
 function escape(val) {

--- a/versioned_docs/version-2.0/reference/global-options.mdx
+++ b/versioned_docs/version-2.0/reference/global-options.mdx
@@ -289,7 +289,7 @@ Directory to use for local process execution sandboxing. The path may be absolut
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.
@@ -361,7 +361,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.
@@ -418,7 +418,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
   env_repr='PANTS_BOOTSTRAPDIR'
   toml_repr={`[GLOBAL]
 pants_bootstrapdir = <dir>`}
-  default_repr={`$XDG_CACHE_HOME/pants`}
+  default_repr={`\$XDG_CACHE_HOME/pants`}
 >
 
 Unused. Will be deprecated in 2.1.0.
@@ -718,7 +718,7 @@ Override config with values from these files, using syntax matching that of `--p
   env_repr='PANTS_PLUGIN_CACHE_DIR'
   toml_repr={`[GLOBAL]
 plugin_cache_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/plugins`}
+  default_repr={`\$XDG_CACHE_HOME/pants/plugins`}
 >
 
 Cache resolved plugin requirements here.

--- a/versioned_docs/version-2.0/reference/subsystems/cookies.mdx
+++ b/versioned_docs/version-2.0/reference/subsystems/cookies.mdx
@@ -34,7 +34,7 @@ None
   env_repr='PANTS_COOKIES_PATH'
   toml_repr={`[cookies]
 path = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/auth/cookies`}
+  default_repr={`\$XDG_CACHE_HOME/pants/auth/cookies`}
   removal_version='2.1.0.dev0'
   removal_hint={'The option `--cookies-path` does not do anything and the `[cookies]` subsystem will be removed.'}
 >

--- a/versioned_docs/version-2.1/reference/global-options.mdx
+++ b/versioned_docs/version-2.1/reference/global-options.mdx
@@ -289,7 +289,7 @@ Directory to use for local process execution sandboxing. The path may be absolut
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.
@@ -361,7 +361,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.
@@ -418,7 +418,7 @@ The name of the script or binary used to invoke Pants. Useful when printing help
   env_repr='PANTS_BOOTSTRAPDIR'
   toml_repr={`[GLOBAL]
 pants_bootstrapdir = <dir>`}
-  default_repr={`$XDG_CACHE_HOME/pants`}
+  default_repr={`\$XDG_CACHE_HOME/pants`}
 >
 
 Unused. Will be deprecated in 2.2.0.
@@ -704,7 +704,7 @@ Override config with values from these files, using syntax matching that of `--p
   env_repr='PANTS_PLUGIN_CACHE_DIR'
   toml_repr={`[GLOBAL]
 plugin_cache_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/plugins`}
+  default_repr={`\$XDG_CACHE_HOME/pants/plugins`}
 >
 
 Cache resolved plugin requirements here.

--- a/versioned_docs/version-2.10/reference/global-options.mdx
+++ b/versioned_docs/version-2.10/reference/global-options.mdx
@@ -429,7 +429,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -567,7 +567,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.11/reference/global-options.mdx
+++ b/versioned_docs/version-2.11/reference/global-options.mdx
@@ -427,7 +427,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -565,7 +565,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.12/reference/global-options.mdx
+++ b/versioned_docs/version-2.12/reference/global-options.mdx
@@ -427,7 +427,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -565,7 +565,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.13/reference/global-options.mdx
+++ b/versioned_docs/version-2.13/reference/global-options.mdx
@@ -472,7 +472,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -610,7 +610,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.13/reference/targets/vcs_version.mdx
+++ b/versioned_docs/version-2.13/reference/targets/vcs_version.mdx
@@ -80,7 +80,7 @@ All dependencies must share the same value for their `resolve` field.
 
 <Field
     type_repr={`str | None`}
-    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$'`}
+    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?\$'`}
 >
 
 A Python regex string to extract the version string from a VCS tag.

--- a/versioned_docs/version-2.14/reference/global-options.mdx
+++ b/versioned_docs/version-2.14/reference/global-options.mdx
@@ -434,7 +434,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -572,7 +572,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.14/reference/targets/vcs_version.mdx
+++ b/versioned_docs/version-2.14/reference/targets/vcs_version.mdx
@@ -80,7 +80,7 @@ All dependencies must share the same value for their `resolve` field.
 
 <Field
     type_repr={`str | None`}
-    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$'`}
+    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?\$'`}
 >
 
 A Python regex string to extract the version string from a VCS tag.

--- a/versioned_docs/version-2.15/reference/global-options.mdx
+++ b/versioned_docs/version-2.15/reference/global-options.mdx
@@ -454,7 +454,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -592,7 +592,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.15/reference/targets/vcs_version.mdx
+++ b/versioned_docs/version-2.15/reference/targets/vcs_version.mdx
@@ -80,7 +80,7 @@ All dependencies must share the same value for their `resolve` field.
 
 <Field
     type_repr={`str | None`}
-    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$'`}
+    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?\$'`}
 >
 
 A Python regex string to extract the version string from a VCS tag.

--- a/versioned_docs/version-2.16/reference/global-options.mdx
+++ b/versioned_docs/version-2.16/reference/global-options.mdx
@@ -454,7 +454,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -592,7 +592,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.16/reference/targets/vcs_version.mdx
+++ b/versioned_docs/version-2.16/reference/targets/vcs_version.mdx
@@ -80,7 +80,7 @@ All dependencies must share the same value for their `resolve` field.
 
 <Field
     type_repr={`str | None`}
-    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$'`}
+    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?\$'`}
 >
 
 A Python regex string to extract the version string from a VCS tag.

--- a/versioned_docs/version-2.17/reference/global-options.mdx
+++ b/versioned_docs/version-2.17/reference/global-options.mdx
@@ -454,7 +454,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -592,7 +592,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.17/reference/targets/vcs_version.mdx
+++ b/versioned_docs/version-2.17/reference/targets/vcs_version.mdx
@@ -80,7 +80,7 @@ All dependencies must share the same value for their `resolve` field.
 
 <Field
     type_repr={`str | None`}
-    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$'`}
+    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?\$'`}
 >
 
 A Python regex string to extract the version string from a VCS tag.

--- a/versioned_docs/version-2.18/reference/global-options.mdx
+++ b/versioned_docs/version-2.18/reference/global-options.mdx
@@ -454,7 +454,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -592,7 +592,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.18/reference/targets/vcs_version.mdx
+++ b/versioned_docs/version-2.18/reference/targets/vcs_version.mdx
@@ -80,7 +80,7 @@ All dependencies must share the same value for their `resolve` field.
 
 <Field
     type_repr={`str | None`}
-    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$'`}
+    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?\$'`}
 >
 
 A Python regex string to extract the version string from a VCS tag.

--- a/versioned_docs/version-2.19/reference/global-options.mdx
+++ b/versioned_docs/version-2.19/reference/global-options.mdx
@@ -454,7 +454,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -592,7 +592,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.19/reference/targets/vcs_version.mdx
+++ b/versioned_docs/version-2.19/reference/targets/vcs_version.mdx
@@ -80,7 +80,7 @@ All dependencies must share the same value for their `resolve` field.
 
 <Field
     type_repr={`str | None`}
-    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$'`}
+    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?\$'`}
 >
 
 A Python regex string to extract the version string from a VCS tag.

--- a/versioned_docs/version-2.2/reference/global-options.mdx
+++ b/versioned_docs/version-2.2/reference/global-options.mdx
@@ -289,7 +289,7 @@ Directory to use for local process execution sandboxing. The path may be absolut
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.
@@ -361,7 +361,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.
@@ -662,7 +662,7 @@ Override config with values from these files, using syntax matching that of `--p
   env_repr='PANTS_PLUGIN_CACHE_DIR'
   toml_repr={`[GLOBAL]
 plugin_cache_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/plugins`}
+  default_repr={`\$XDG_CACHE_HOME/pants/plugins`}
 >
 
 Cache resolved plugin requirements here.

--- a/versioned_docs/version-2.20/reference/global-options.mdx
+++ b/versioned_docs/version-2.20/reference/global-options.mdx
@@ -479,7 +479,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -617,7 +617,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.20/reference/targets/vcs_version.mdx
+++ b/versioned_docs/version-2.20/reference/targets/vcs_version.mdx
@@ -91,7 +91,7 @@ All dependencies must share the same value for their `resolve` field.
 
 <Field
     type_repr={`str | None`}
-    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$'`}
+    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?\$'`}
 >
 
 A Python regex string to extract the version string from a VCS tag.

--- a/versioned_docs/version-2.21/reference/global-options.mdx
+++ b/versioned_docs/version-2.21/reference/global-options.mdx
@@ -479,7 +479,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -617,7 +617,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.21/reference/targets/vcs_version.mdx
+++ b/versioned_docs/version-2.21/reference/targets/vcs_version.mdx
@@ -91,7 +91,7 @@ All dependencies must share the same value for their `resolve` field.
 
 <Field
     type_repr={`str | None`}
-    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$'`}
+    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?\$'`}
 >
 
 A Python regex string to extract the version string from a VCS tag.

--- a/versioned_docs/version-2.22/reference/global-options.mdx
+++ b/versioned_docs/version-2.22/reference/global-options.mdx
@@ -502,7 +502,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -640,7 +640,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.22/reference/subsystems/jvm.mdx
+++ b/versioned_docs/version-2.22/reference/subsystems/jvm.mdx
@@ -70,7 +70,7 @@ deploy_jar_exclude_files = [
     '<str>',
     ...,
 ]`}
-  default_repr={`[\n  "^META-INF/[^/]+\\.SF$",\n  "^META-INF/[^/]+\\.DSA$",\n  "^META-INF/[^/]+\\.RSA$",\n  "META-INF/INDEX.LIST$"\n]`}
+  default_repr={`[\n  "^META-INF/[^/]+\\.SF\$",\n  "^META-INF/[^/]+\\.DSA\$",\n  "^META-INF/[^/]+\\.RSA\$",\n  "META-INF/INDEX.LIST\$"\n]`}
 >
 
 A list of patterns to exclude from all deploy jars. An individual deploy_jar target can also exclude other files, in addition to these, by setting its `exclude_files` field.

--- a/versioned_docs/version-2.22/reference/targets/vcs_version.mdx
+++ b/versioned_docs/version-2.22/reference/targets/vcs_version.mdx
@@ -91,7 +91,7 @@ All dependencies must share the same value for their `resolve` field.
 
 <Field
     type_repr={`str | None`}
-    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$'`}
+    default_repr={`'^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?\$'`}
 >
 
 A Python regex string to extract the version string from a VCS tag.

--- a/versioned_docs/version-2.3/reference/global-options.mdx
+++ b/versioned_docs/version-2.3/reference/global-options.mdx
@@ -289,7 +289,7 @@ Directory to use for local process execution sandboxing. The path may be absolut
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.
@@ -361,7 +361,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.
@@ -1202,7 +1202,7 @@ Verify that all config file values correspond to known options.
   env_repr='PANTS_PLUGIN_CACHE_DIR'
   toml_repr={`[GLOBAL]
 plugin_cache_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/plugins`}
+  default_repr={`\$XDG_CACHE_HOME/pants/plugins`}
   removal_version='2.5.0.dev0'
   removal_hint={'This option now no-ops, the plugins cache is now housed in the named caches.'}
 >

--- a/versioned_docs/version-2.4/reference/global-options.mdx
+++ b/versioned_docs/version-2.4/reference/global-options.mdx
@@ -289,7 +289,7 @@ Directory to use for local process execution sandboxing. The path may be absolut
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.
@@ -425,7 +425,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches. The path may be absolute or relative. If the directory is within the build root, be sure to include it in `--pants-ignore`.
@@ -1273,7 +1273,7 @@ Verify that all config file values correspond to known options.
   env_repr='PANTS_PLUGIN_CACHE_DIR'
   toml_repr={`[GLOBAL]
 plugin_cache_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/plugins`}
+  default_repr={`\$XDG_CACHE_HOME/pants/plugins`}
   removal_version='2.5.0.dev0'
   removal_hint={'This option now no-ops, the plugins cache is now housed in the named caches.'}
 >

--- a/versioned_docs/version-2.5/reference/global-options.mdx
+++ b/versioned_docs/version-2.5/reference/global-options.mdx
@@ -298,7 +298,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -436,7 +436,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.6/reference/global-options.mdx
+++ b/versioned_docs/version-2.6/reference/global-options.mdx
@@ -300,7 +300,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -438,7 +438,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.7/reference/global-options.mdx
+++ b/versioned_docs/version-2.7/reference/global-options.mdx
@@ -316,7 +316,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -454,7 +454,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.8/reference/global-options.mdx
+++ b/versioned_docs/version-2.8/reference/global-options.mdx
@@ -324,7 +324,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -462,7 +462,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.

--- a/versioned_docs/version-2.9/reference/global-options.mdx
+++ b/versioned_docs/version-2.9/reference/global-options.mdx
@@ -414,7 +414,7 @@ The path may be absolute or relative. If the directory is within the build root,
   env_repr='PANTS_LOCAL_STORE_DIR'
   toml_repr={`[GLOBAL]
 local_store_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/lmdb_store`}
+  default_repr={`\$XDG_CACHE_HOME/pants/lmdb_store`}
 >
 
 Directory to use for the local file store, which stores the results of subprocesses run by Pants.
@@ -552,7 +552,7 @@ The maximum number of times to loop when `--loop` is specified.
   env_repr='PANTS_NAMED_CACHES_DIR'
   toml_repr={`[GLOBAL]
 named_caches_dir = <str>`}
-  default_repr={`$XDG_CACHE_HOME/pants/named_caches`}
+  default_repr={`\$XDG_CACHE_HOME/pants/named_caches`}
 >
 
 Directory to use for named global caches for tools and processes with trusted, concurrency-safe caches.


### PR DESCRIPTION
This escapes `$` in default values to avoid them being treated as template literal substitutions.

Default values end up in a template literal `` `something` ``. If the string contains `${...}` literally, they'll be treated as a substitution. This PR escapes all `$`s to avoid this.

This bug/oversight doesn't cause problems with any _current_ values, but will be required in 2.23.0.dev4 due to the new default value for `output_path` fields from https://github.com/pantsbuild/pants/pull/21175.

Example of the effect (from https://github.com/pantsbuild/pantsbuild.org/pull/234#discussion_r1690867967):

```diff
- default_repr={`'${spec_path_normalized}/${target_name_normalized}${file_suffix}'`}
+ default_repr={`'\${spec_path_normalized}/\${target_name_normalized}\${file_suffix}'`}
```