### PR TITLE
use friendly "semi-stable" urls for key versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,8 +52,8 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: npm run build
         env:
+          NODE_ENV: "production"
           NODE_OPTIONS: --max-old-space-size=12288
-
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ PANTSBUILD_ORG_INCLUDE_VERSIONS=$version1,$version2 npm start
 To build the site, run:
 
 ```bash
-NODE_OPTIONS="--max-old-space-size=12288" npm run build
+NODE_ENV=production NODE_OPTIONS="--max-old-space-size=12288" npm run build
 ```
 
 (Note: Node needs more than the default amount of RAM because this site is beefy)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -447,16 +447,16 @@ const config = {
       {
         redirects: old_site_redirects,
         createRedirects(existingPath) {
-          if (existingPath.includes("/dev/")) {
+          if (existingPath.startsWith("/dev/")) {
             return [existingPath.replace("/dev/", `/${currentVersion}/`)];
-          } else if (existingPath.includes("/prerelease/")) {
+          } else if (existingPath.startsWith("/prerelease/")) {
             return [
               existingPath.replace(
                 "/prerelease/",
                 `/${mostRecentPreReleaseVersion.shortVersion}/`
               ),
             ];
-          } else if (existingPath.includes("/stable/")) {
+          } else if (existingPath.startsWith("/stable/")) {
             return [
               existingPath.replace(
                 "/stable/",


### PR DESCRIPTION
Currently all of the versioned docs have the explicit version in the url.  This has the virtue of being
[cool](https://www.w3.org/Provider/Style/URI) but has some awkwardness in practice.  For example if one links to
https://www.pantsbuild.org/2.18/docs/using-pants/using-pants-in-ci from another webpage it will eventualy end up with the 'no longer maintained' banner.  It isn't super fun to update every internal/wiki link every 6 weeks for a release.

This change introduces some "semi-stable" urls for key versions:
 * `prerelease`: The latest prerelease
 * `dev`: aka `main` aka "trunk"
 * `stable`: The most recent stable release

Redirects ensure that the versioned urls also work.

As an example, right now:

`/stable/docs/using-pants/using-pants-in-ci` is the doc for `2.21` and `/2.21//docs/using-pants/using-pants-in-ci` redirects to there.  After the next release, `/stable/docs/using-pants/using-pants-in-ci` will be for `2.22` and `/2.21/docs/using-pants/using-pants-in-ci` will keep pointing to the `2.21` content.

I think this is reasonable compromise of easy of use with permanence.

FWIW the Offical Docusaurus position seems to be to prefer server side redirects https://github.com/facebook/docusaurus/issues/9049 but as far as I can tell that isn't an option for GitHub Pages.

ref #221