### PR TITLE
detect mostRecentPreReleaseVersion in a way that actually works

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -142,7 +142,7 @@ const getVersionDetails = () => {
 const versionDetails = getVersionDetails();
 
 const mostRecentPreReleaseVersion = versionDetails.find(
-  ({ isMaintained }) => !isMaintained
+  (ver) => ver.isPrerelease && !ver.isCurrent
 );
 
 const mostRecentStableVersion = versionDetails.find(


### PR DESCRIPTION
Followup to 6136389.  The redirect for /stable and /dev worked, but not /prerelease.

Test on fully built site:
```
$ curl http://localhost:3000/2.22/docs/introduction/welcome-to-pants
<!DOCTYPE html>
<html>
  <head>
    <meta charset="UTF-8">
    <meta http-equiv="refresh" content="0; url=/prerelease/docs/introduction/welcome-to-pants">
    <link rel="canonical" href="/prerelease/docs/introduction/welcome-to-pants" />
  </head>
  <script>
    window.location.href = '/prerelease/docs/introduction/welcome-to-pants' + window.location.search + window.location.hash;
  </script>
```