### PR TITLE
add announcement bar for the 2024 User Survey

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -237,7 +237,8 @@ const config = {
   themeConfig: {
     // Temporary: Announce the 2024 User Survey.
     announcementBar: {
-      content: 'The Pantsbuild 2024 User Survey is live! Check out the <a href="/blog/2024/10/08/user-survey-2024">blog post</a> or <a target="_blank" href="https://forms.gle/eo7Y4DuxurjaMSZn6">take the survey</a>.',
+      content:
+        'The Pantsbuild 2024 User Survey is live! Check out the <a href="/blog/2024/10/08/user-survey-2024">blog post</a> or <a target="_blank" href="https://forms.gle/eo7Y4DuxurjaMSZn6">take the survey</a>.',
     },
     image: "img/social-card.png",
     navbar: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -235,6 +235,10 @@ const config = {
   ],
 
   themeConfig: {
+    // Temporary: Announce the 2024 User Survey.
+    announcementBar: {
+      content: 'The Pantsbuild 2024 User Survey is live! Check out the <a href="/blog/2024/10/08/user-survey-2024">blog post</a> or <a target="_blank" href="https://forms.gle/eo7Y4DuxurjaMSZn6">take the survey</a>.',
+    },
     image: "img/social-card.png",
     navbar: {
       title: "Pantsbuild",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,3 +36,20 @@ figcaption {
 .color--success {
   color: var(--ifm-color-primary);
 }
+
+/* Announcement Bar styling */
+div[class*='AnnouncementBar'] {
+  /* Make the announcement text more prominent. */
+  font-size: 24px !important;
+}
+
+div[class*='AnnouncementBar'] a {
+  /* Default link style does not use a different color. */
+  color: var(--ifm-link-color);
+  text-decoration: inherit;
+}
+
+div[class*='AnnouncementBar'] a:hover {
+  color: var(--ifm-link-color);
+  text-decoration: underline;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -38,18 +38,18 @@ figcaption {
 }
 
 /* Announcement Bar styling */
-div[class*='AnnouncementBar'] {
+div[class*="AnnouncementBar"] {
   /* Make the announcement text more prominent. */
   font-size: 24px !important;
 }
 
-div[class*='AnnouncementBar'] a {
+div[class*="AnnouncementBar"] a {
   /* Default link style does not use a different color. */
   color: var(--ifm-link-color);
   text-decoration: inherit;
 }
 
-div[class*='AnnouncementBar'] a:hover {
+div[class*="AnnouncementBar"] a:hover {
   color: var(--ifm-link-color);
   text-decoration: underline;
 }


### PR DESCRIPTION
Add an announcement bar to announce the 2024 Pantsbuild User Survey. I added some custom styles to (1) make the text larger and (2) to restore default link colors.

Screenshot: 
<img width="1788" alt="Screenshot 2024-10-08 at 22 59 11" src="https://github.com/user-attachments/assets/d3b38cf4-e827-460d-bbd7-5c5b766ccc5d">
