### PR TITLE
Fix links to release notes in 2.23.0 blog post.

### DIFF
--- a/blog/2024-09-10-pants-2-22/index.mdx
+++ b/blog/2024-09-10-pants-2-22/index.mdx
@@ -16,7 +16,7 @@
 
 {/* truncate */}
 
-We are pleased to announce Pants [2.22.0](<(https://github.com/pantsbuild/pants/tree/2.22.x/src/python/pants/notes/2.22.x.md)>), the latest release of [Pantsbuild, the scalable and ergonomic build system](https://www.pantsbuild.org/). To update, set `pants_version = "2.22.0"` in your `pants.toml`. If you're not using Pants yet, [get started now](https://www.pantsbuild.org/2.22/docs/getting-started).
+We are pleased to announce Pants [2.22.0](<(https://github.com/pantsbuild/pants/tree/2.22.x/docs/notes/2.22.x.md)>), the latest release of [Pantsbuild, the scalable and ergonomic build system](https://www.pantsbuild.org/). To update, set `pants_version = "2.22.0"` in your `pants.toml`. If you're not using Pants yet, [get started now](https://www.pantsbuild.org/2.22/docs/getting-started).
 
 _Highlights in [2.22](<(https://github.com/pantsbuild/pants/tree/2.22.x/src/python/pants/notes/2.22.x.md)>) include_:
 
@@ -33,7 +33,7 @@ _Highlights in [2.22](<(https://github.com/pantsbuild/pants/tree/2.22.x/src/pyth
 - 🎒 The ability to bundle `openapi_document` and its `openapi_source` dependencies into a single file, for consumption by other targets.
 - 📈 And lots of smaller features, update, bugfixes, and general improvements
 
-Check out the [full release notes](https://github.com/pantsbuild/pants/tree/2.22.x/src/python/pants/notes/2.22.x.md). Pants is an open-source project, and the changes are all contributed by our community. If you want to see something more in the next changelog, join us on [GitHub](https://github.com/pantsbuild/pants) and become a contributor.
+Check out the [full release notes](https://github.com/pantsbuild/pants/tree/2.22.x/docs/notes/2.22.x.md). Pants is an open-source project, and the changes are all contributed by our community. If you want to see something more in the next changelog, join us on [GitHub](https://github.com/pantsbuild/pants) and become a contributor.
 
 In particular, please note the transition to the new options system. In 2.22.x we run both the new and the legacy systems concurrently and compare the results, issuing warnings if there are any discrepancies. If you do encounter discrepancies that you can't resolve on your own, please [reach out to us!](https://www.pantsbuild.org/community/getting-help).
 

--- a/blog/2024-09-10-pants-2-22/index.mdx
+++ b/blog/2024-09-10-pants-2-22/index.mdx
@@ -18,7 +18,7 @@
 
 We are pleased to announce Pants [2.22.0](https://github.com/pantsbuild/pants/tree/2.22.x/docs/notes/2.22.x.md), the latest release of [Pantsbuild, the scalable and ergonomic build system](https://www.pantsbuild.org/). To update, set `pants_version = "2.22.0"` in your `pants.toml`. If you're not using Pants yet, [get started now](https://www.pantsbuild.org/2.22/docs/getting-started).
 
-_Highlights in [2.22](<(https://github.com/pantsbuild/pants/tree/2.22.x/docs/notes/2.22.x.md)>) include_:
+_Highlights in [2.22](https://github.com/pantsbuild/pants/tree/2.22.x/docs/notes/2.22.x.md) include_:
 
 - 🎛 A major re-implementation of the Pants [options system](https://www.pantsbuild.org/2.22/docs/using-pants/key-concepts/options). See below for more!
 - 🏠 Support for executing local processes within the repository itself (rather than in a sandbox) via the new [workspace environment](https://www.pantsbuild.org/stable/docs/using-pants/environments#in-workspace-execution-experimental_workspace_environment) feature.

--- a/blog/2024-09-10-pants-2-22/index.mdx
+++ b/blog/2024-09-10-pants-2-22/index.mdx
@@ -16,7 +16,7 @@
 
 {/* truncate */}
 
-We are pleased to announce Pants [2.22.0](<(https://github.com/pantsbuild/pants/tree/2.22.x/docs/notes/2.22.x.md)>), the latest release of [Pantsbuild, the scalable and ergonomic build system](https://www.pantsbuild.org/). To update, set `pants_version = "2.22.0"` in your `pants.toml`. If you're not using Pants yet, [get started now](https://www.pantsbuild.org/2.22/docs/getting-started).
+We are pleased to announce Pants [2.22.0](https://github.com/pantsbuild/pants/tree/2.22.x/docs/notes/2.22.x.md), the latest release of [Pantsbuild, the scalable and ergonomic build system](https://www.pantsbuild.org/). To update, set `pants_version = "2.22.0"` in your `pants.toml`. If you're not using Pants yet, [get started now](https://www.pantsbuild.org/2.22/docs/getting-started).
 
 _Highlights in [2.22](<(https://github.com/pantsbuild/pants/tree/2.22.x/src/python/pants/notes/2.22.x.md)>) include_:
 

--- a/blog/2024-09-10-pants-2-22/index.mdx
+++ b/blog/2024-09-10-pants-2-22/index.mdx
@@ -18,7 +18,7 @@
 
 We are pleased to announce Pants [2.22.0](https://github.com/pantsbuild/pants/tree/2.22.x/docs/notes/2.22.x.md), the latest release of [Pantsbuild, the scalable and ergonomic build system](https://www.pantsbuild.org/). To update, set `pants_version = "2.22.0"` in your `pants.toml`. If you're not using Pants yet, [get started now](https://www.pantsbuild.org/2.22/docs/getting-started).
 
-_Highlights in [2.22](<(https://github.com/pantsbuild/pants/tree/2.22.x/src/python/pants/notes/2.22.x.md)>) include_:
+_Highlights in [2.22](<(https://github.com/pantsbuild/pants/tree/2.22.x/docs/notes/2.22.x.md)>) include_:
 
 - 🎛 A major re-implementation of the Pants [options system](https://www.pantsbuild.org/2.22/docs/using-pants/key-concepts/options). See below for more!
 - 🏠 Support for executing local processes within the repository itself (rather than in a sandbox) via the new [workspace environment](https://www.pantsbuild.org/stable/docs/using-pants/environments#in-workspace-execution-experimental_workspace_environment) feature.

--- a/blog/2024-11-20-pants-2-23/index.mdx
+++ b/blog/2024-11-20-pants-2-23/index.mdx
@@ -26,7 +26,7 @@ A couple of administrative reminders:
 - We're very proud that Pants now has its first [sponsors](https://www.pantsbuild.org/sponsors)! We are very grateful to [Klayvio](https://www.klaviyo.com/) and [Normal Computing](https://normalcomputing.ai/) for their Platinum tier support, and to [Continua](https://www.continua.ai/) and Stormfish for their Silver tier support.
   Sponsoring is a way for companies that use Pants to support the project while engaging more closely with the community. Want to support Pants? Find out more about our [sponsorship opportunities](https://www.pantsbuild.org/sponsorship) and the associated benefits at each tier.
 
-_Highlights in [2.23](https://github.com/pantsbuild/pants/tree/2.23.x/src/python/pants/notes/2.23.x.md) include_:
+_Highlights in [2.23](https://github.com/pantsbuild/pants/blob/2.23.x/docs/notes/2.23.x.md) include_:
 
 - 🌖 Due to deprecations by GitHub, the minimum supported glibc version for Pants wheels is now 2.28. Unless you are running Pants with in-repo plugins on a Linux distro from before 2018, this should have no effect.
 - ✨ A new backend for the [buildifier](https://github.com/bazelbuild/buildtools/blob/main/buildifier/README.md) BUILD file formatter.

--- a/blog/2024-11-20-pants-2-23/index.mdx
+++ b/blog/2024-11-20-pants-2-23/index.mdx
@@ -16,7 +16,7 @@
 
 {/* truncate */}
 
-We are pleased to announce Pants [2.23.0](<(https://github.com/pantsbuild/pants/tree/2.23.x/src/python/pants/notes/2.23.x.md)>), the latest release of [Pantsbuild, the scalable and ergonomic build system](https://www.pantsbuild.org/). To update, set `pants_version = "2.23.0"` in your `pants.toml`. If you're not using Pants yet, [get started now](https://www.pantsbuild.org/2.23/docs/getting-started).
+We are pleased to announce Pants [2.23.0](<(https://github.com/pantsbuild/pants/blob/2.23.x/docs/notes/2.23.x.md)>), the latest release of [Pantsbuild, the scalable and ergonomic build system](https://www.pantsbuild.org/). To update, set `pants_version = "2.23.0"` in your `pants.toml`. If you're not using Pants yet, [get started now](https://www.pantsbuild.org/2.23/docs/getting-started).
 
 The previous release, 2.22.0, suffered from delays in its release cycle. So this 2.23.0 release is a relatively fast follow, and does not introduce major upheavals.
 
@@ -38,7 +38,7 @@ _Highlights in [2.23](https://github.com/pantsbuild/pants/tree/2.23.x/src/python
 
 As in the previous release, in 2.23.x we continue to run both the new and the legacy options systems concurrently and compare the results, issuing warnings if there are any discrepancies. If you do encounter discrepancies that you can't resolve on your own, please [reach out to us!](https://www.pantsbuild.org/community/getting-help).
 
-Check out the [full release notes](https://github.com/pantsbuild/pants/tree/2.23.x/src/python/pants/notes/2.23.x.md). Pants is an open-source project, and the changes are all contributed by our community. If you want to see something more in the next changelog, join us on [GitHub](https://github.com/pantsbuild/pants) and become a contributor.
+Check out the [full release notes](https://github.com/pantsbuild/pants/blob/2.23.x/docs/notes/2.23.x.md). Pants is an open-source project, and the changes are all contributed by our community. If you want to see something more in the next changelog, join us on [GitHub](https://github.com/pantsbuild/pants) and become a contributor.
 
 As mentioned above, we offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/sponsorship), as well as individual sponsorships via [GitHub](https://github.com/sponsors/pantsbuild). These help pay for the ongoing development and hosting costs, and are managed by the Pants Build non-profit organization.
 

--- a/blog/2024-11-20-pants-2-23/index.mdx
+++ b/blog/2024-11-20-pants-2-23/index.mdx
@@ -16,7 +16,7 @@
 
 {/* truncate */}
 
-We are pleased to announce Pants [2.23.0](<(https://github.com/pantsbuild/pants/blob/2.23.x/docs/notes/2.23.x.md)>), the latest release of [Pantsbuild, the scalable and ergonomic build system](https://www.pantsbuild.org/). To update, set `pants_version = "2.23.0"` in your `pants.toml`. If you're not using Pants yet, [get started now](https://www.pantsbuild.org/2.23/docs/getting-started).
+We are pleased to announce Pants [2.23.0](https://github.com/pantsbuild/pants/blob/2.23.x/docs/notes/2.23.x.md), the latest release of [Pantsbuild, the scalable and ergonomic build system](https://www.pantsbuild.org/). To update, set `pants_version = "2.23.0"` in your `pants.toml`. If you're not using Pants yet, [get started now](https://www.pantsbuild.org/2.23/docs/getting-started).
 
 The previous release, 2.22.0, suffered from delays in its release cycle. So this 2.23.0 release is a relatively fast follow, and does not introduce major upheavals.
 


### PR DESCRIPTION
The old link pointed to a nonexistent page.

Also fix links in the 2.22.0 post that 2.23.0 was
copy-pasta'd from. Those links weren't broken,
but they led to a redirection page, so might as
well point them to the target location.