### PR TITLE
Fix "Add your org" link, hide "Add your testimonial" one

### DIFF
--- a/src/pages/spotlight/testimonials.mdx
+++ b/src/pages/spotlight/testimonials.mdx
@@ -14,9 +14,7 @@ export function Header() {
         Pants is helping piles of software teams. Here's what some of them have
         to say.
       </p>
-      <Link className="button button--primary" to="/404">
-        Add your testimonial
-      </Link>
+      {/*<Link className="button button--primary" to="/404">Add your testimonial</Link>*/}
     </section>
   );
 }

--- a/src/pages/spotlight/users.mdx
+++ b/src/pages/spotlight/users.mdx
@@ -15,7 +15,7 @@ export function Header() {
         Pants is making engineering teams productive and happy at a range of
         companies and organizations.
       </p>
-      <Link className="button button--primary" to="/404">
+      <Link className="button button--primary" to="/register">
         Add your organization or company
       </Link>
     </section>


### PR DESCRIPTION
This fixes two links that were previously explicitly pointing at the 404 page, after the migration from the old site:

- the "Add your organization or company" link on the user spotlight page, which used to point to https://pantsbuild.org/register : this still works (appears to be 301 redirect configured in CloudFlare?), and redirects to a GitHub issue template.
- the "Add your testimionial" link on the testimonials page, which didn't previously exist (https://web.archive.org/web/20230604011655/https://www.pantsbuild.org/docs/testimonials). I've hidden this one to at least not have a wildly broken link in people's face, but we can restore it once we have an appropriate process. (Although I imagine most people looking at the testimonials page will be _new_ users, i.e. not in a position to write a testimonial yet.)

This was noticed by a user on slack: https://pantsbuild.slack.com/archives/C046T6T9U/p1735280301069719. Thanks!