### PR TITLE
remove announcement bar link to the now-closed user survey

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -235,11 +235,6 @@ const config = {
   ],
 
   themeConfig: {
-    // Temporary: Announce the 2024 User Survey.
-    announcementBar: {
-      content:
-        'The Pantsbuild 2024 User Survey is live! Check out the <a href="/blog/2024/10/08/user-survey-2024">blog post</a> or <a target="_blank" href="https://forms.gle/eo7Y4DuxurjaMSZn6">take the survey</a>.',
-    },
     image: "img/social-card.png",
     navbar: {
       title: "Pantsbuild",


### PR DESCRIPTION
The 2024 user survey is now closed so remove the announcement bar link to it.