### PR TITLE
update to the latest pages action so that it might work again

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,4 +62,4 @@ jobs:
           path: "./build"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "./build"
       - name: Deploy to GitHub Pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,4 +62,4 @@ jobs:
           path: "./build"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v3


### PR DESCRIPTION
The last docs update failed with:
https://github.com/pantsbuild/pantsbuild.org/actions/runs/12934911051/job/36077004632

```
Getting action download info
Download action repository 'actions/checkout@v3' (SHA:f43a0e5ff2bd294095638e18286ca9a3d1956744)
Download action repository 'actions/setup-node@v3' (SHA:1a4442cacd436585916779262731d5b162bc6ec7)
Download action repository 'actions/cache@v3' (SHA:f4b3439a656ba812b8cb417d2d49f9c810103092)
Download action repository 'actions/configure-pages@v3' (SHA:b8130d9ab958b325bbde9786d62f2c97a9885a0e)
Download action repository 'actions/upload-pages-artifact@v2' (SHA:a753861a5debcf57bf8b404356158c8e1e33150c)
Download action repository 'actions/deploy-pages@v2' (SHA:de14547edc9944350dc0481aa5b7afb08e75f254)
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

This is presumably from a transitive dependency from `deploy-pages@v2` to the deprecated action.