### PR TITLE
Remove Normal Computing from sponsors page.

### DIFF
--- a/src/pages/sponsors.mdx
+++ b/src/pages/sponsors.mdx
@@ -13,13 +13,6 @@ The maintainers and users of Pants are grateful to:
 
 [Klaviyo](https://www.klaviyo.com/) (CLAY-vee-oh) powers smarter digital relationships, making it easy for businesses to capture, store, analyze, and predictively use their own data to drive measurable, high-value outcomes. Klaviyo's modern and intuitive SaaS platform enables business users of any skill level to harness their first-party data from more than 350 integrations to send the right message at the right time across email, SMS, and push notifications. Innovative businesses like Good American, TaylorMade, Liquid Death, Stanley 1913, and more than 146,000 other paying customers leverage Klaviyo to acquire, engage, and retain customers—and grow on their own terms. [And they're hiring!](https://www.klaviyo.com/careers)
 
-<br></br>
-<CaptionedImg
-  src={require("./sponsor_logos/normalcomputing.png").default}
-></CaptionedImg>
-
-[Normal Computing](https://normalcomputing.ai/) is an AI and hardware company pushing fundamental possibility limits of reasoning by unifying AI with the physical world. Normal Computing was founded by former members of the Google Brain Team, Palantir, and X that pioneered industry-leading Physics + ML tools for next-gen AI. [And they're hiring!](https://jobs.ashbyhq.com/Normal%20Computing%20AI)
-
 [//]: # "# Gold Sponsors"
 
 # Our Silver Sponsors


### PR DESCRIPTION
They have decided to end their sponsorship.