### PR TITLE
Made `pnpm` aware of nested `package.json` for `sync-docs`

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -57,12 +57,14 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
+          package_json_file: "pantsbuild.org/package.json"
 
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
+          cache-dependency-path: "pantsbuild.org/pnpm-lock.yaml"
 
       - name: Get pnpm store directory
         id: pnpm-cache


### PR DESCRIPTION
Missed that before, and previously npm was hardcoded to a version (independent of what was in the package.json).