### PR TITLE
Replaced broken `register` link with one to Github's registration template

### DIFF
--- a/src/pages/spotlight/users.mdx
+++ b/src/pages/spotlight/users.mdx
@@ -15,8 +15,11 @@ export function Header() {
         Pants is making engineering teams productive and happy at a range of
         companies and organizations.
       </p>
-      <Link className="button button--primary" to="/register">
-        Add your organization or company
+      <Link
+        className="button button--primary"
+        to="https://github.com/pantsbuild/pants/issues/new?template=user_registration.yml"
+      >
+        Add your Organization or Company
       </Link>
     </section>
   );


### PR DESCRIPTION
Closes #379 