### PR TITLE
Update swc, pnpm, and ignore react updates from depbot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,5 +17,10 @@ updates:
       npm-deps:
         patterns:
           - "*"
+        ignore:
+    ignore:
+      # SJ (2026-01-12): The next update is React 19.x. It has a lot of audit patches and broke our markdown parsing. Ignore until Docu 4.x
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
     schedule:
       interval: "weekly"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@docusaurus/faster": "^3.9.2",
     "@docusaurus/module-type-aliases": "^3.9.2",
     "@docusaurus/types": "^3.9.2",
-    "@swc/core": "^1.15.7",
+    "@swc/core": "^1.15.8",
     "he": "^1.2.0",
     "mustache": "^4.2.0",
     "prettier": "^3.7.4"
@@ -58,5 +58,5 @@
     "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
   },
-  "packageManager": "pnpm@10.26.2+sha512.0e308ff2005fc7410366f154f625f6631ab2b16b1d2e70238444dd6ae9d630a8482d92a451144debc492416896ed16f7b114a86ec68b8404b2443869e68ffda6"
+  "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,24 +4,27 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  qs@<6.14.1: ">=6.14.1"
+
 importers:
   .:
     dependencies:
       "@docusaurus/core":
         specifier: ^3.9.2
-        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       "@docusaurus/plugin-client-redirects":
         specifier: ^3.9.2
-        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       "@docusaurus/plugin-content-docs":
         specifier: ^3.9.2
-        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       "@docusaurus/preset-classic":
         specifier: ^3.9.2
-        version: 3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
       "@docusaurus/theme-common":
         specifier: ^3.9.2
-        version: 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@mdx-js/react":
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.7)(react@18.3.1)
@@ -49,16 +52,16 @@ importers:
         version: 3.9.2(eslint@8.57.1)(typescript@5.9.3)
       "@docusaurus/faster":
         specifier: ^3.9.2
-        version: 3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       "@docusaurus/module-type-aliases":
         specifier: ^3.9.2
-        version: 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@docusaurus/types":
         specifier: ^3.9.2
-        version: 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@swc/core":
-        specifier: ^1.15.7
-        version: 1.15.7
+        specifier: ^1.15.8
+        version: 1.15.8
       he:
         specifier: ^1.2.0
         version: 1.2.0
@@ -2470,104 +2473,104 @@ packages:
       }
     engines: { node: ">=14" }
 
-  "@swc/core-darwin-arm64@1.15.7":
+  "@swc/core-darwin-arm64@1.15.8":
     resolution:
       {
-        integrity: sha512-+hNVUfezUid7LeSHqnhoC6Gh3BROABxjlDNInuZ/fie1RUxaEX4qzDwdTgozJELgHhvYxyPIg1ro8ibnKtgO4g==,
+        integrity: sha512-M9cK5GwyWWRkRGwwCbREuj6r8jKdES/haCZ3Xckgkl8MUQJZA3XB7IXXK1IXRNeLjg6m7cnoMICpXv1v1hlJOg==,
       }
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [darwin]
 
-  "@swc/core-darwin-x64@1.15.7":
+  "@swc/core-darwin-x64@1.15.8":
     resolution:
       {
-        integrity: sha512-ZAFuvtSYZTuXPcrhanaD5eyp27H8LlDzx2NAeVyH0FchYcuXf0h5/k3GL9ZU6Jw9eQ63R1E8KBgpXEJlgRwZUQ==,
+        integrity: sha512-j47DasuOvXl80sKJHSi2X25l44CMc3VDhlJwA7oewC1nV1VsSzwX+KOwE5tLnfORvVJJyeiXgJORNYg4jeIjYQ==,
       }
     engines: { node: ">=10" }
     cpu: [x64]
     os: [darwin]
 
-  "@swc/core-linux-arm-gnueabihf@1.15.7":
+  "@swc/core-linux-arm-gnueabihf@1.15.8":
     resolution:
       {
-        integrity: sha512-K3HTYocpqnOw8KcD8SBFxiDHjIma7G/X+bLdfWqf+qzETNBrzOub/IEkq9UaeupaJiZJkPptr/2EhEXXWryS/A==,
+        integrity: sha512-siAzDENu2rUbwr9+fayWa26r5A9fol1iORG53HWxQL1J8ym4k7xt9eME0dMPXlYZDytK5r9sW8zEA10F2U3Xwg==,
       }
     engines: { node: ">=10" }
     cpu: [arm]
     os: [linux]
 
-  "@swc/core-linux-arm64-gnu@1.15.7":
+  "@swc/core-linux-arm64-gnu@1.15.8":
     resolution:
       {
-        integrity: sha512-HCnVIlsLnCtQ3uXcXgWrvQ6SAraskLA9QJo9ykTnqTH6TvUYqEta+TdTdGjzngD6TOE7XjlAiUs/RBtU8Z0t+Q==,
+        integrity: sha512-o+1y5u6k2FfPYbTRUPvurwzNt5qd0NTumCTFscCNuBksycloXY16J8L+SMW5QRX59n4Hp9EmFa3vpvNHRVv1+Q==,
       }
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@swc/core-linux-arm64-musl@1.15.7":
+  "@swc/core-linux-arm64-musl@1.15.8":
     resolution:
       {
-        integrity: sha512-/OOp9UZBg4v2q9+x/U21Jtld0Wb8ghzBScwhscI7YvoSh4E8RALaJ1msV8V8AKkBkZH7FUAFB7Vbv0oVzZsezA==,
+        integrity: sha512-koiCqL09EwOP1S2RShCI7NbsQuG6r2brTqUYE7pV7kZm9O17wZ0LSz22m6gVibpwEnw8jI3IE1yYsQTVpluALw==,
       }
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@swc/core-linux-x64-gnu@1.15.7":
+  "@swc/core-linux-x64-gnu@1.15.8":
     resolution:
       {
-        integrity: sha512-VBbs4gtD4XQxrHuQ2/2+TDZpPQQgrOHYRnS6SyJW+dw0Nj/OomRqH+n5Z4e/TgKRRbieufipeIGvADYC/90PYQ==,
+        integrity: sha512-4p6lOMU3bC+Vd5ARtKJ/FxpIC5G8v3XLoPEZ5s7mLR8h7411HWC/LmTXDHcrSXRC55zvAVia1eldy6zDLz8iFQ==,
       }
     engines: { node: ">=10" }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@swc/core-linux-x64-musl@1.15.7":
+  "@swc/core-linux-x64-musl@1.15.8":
     resolution:
       {
-        integrity: sha512-kVuy2unodso6p0rMauS2zby8/bhzoGRYxBDyD6i2tls/fEYAE74oP0VPFzxIyHaIjK1SN6u5TgvV9MpyJ5xVug==,
+        integrity: sha512-z3XBnbrZAL+6xDGAhJoN4lOueIxC/8rGrJ9tg+fEaeqLEuAtHSW2QHDHxDwkxZMjuF/pZ6MUTjHjbp8wLbuRLA==,
       }
     engines: { node: ">=10" }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@swc/core-win32-arm64-msvc@1.15.7":
+  "@swc/core-win32-arm64-msvc@1.15.8":
     resolution:
       {
-        integrity: sha512-uddYoo5Xmo1XKLhAnh4NBIyy5d0xk33x1sX3nIJboFySLNz878ksCFCZ3IBqrt1Za0gaoIWoOSSSk0eNhAc/sw==,
+        integrity: sha512-djQPJ9Rh9vP8GTS/Df3hcc6XP6xnG5c8qsngWId/BLA9oX6C7UzCPAn74BG/wGb9a6j4w3RINuoaieJB3t+7iQ==,
       }
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [win32]
 
-  "@swc/core-win32-ia32-msvc@1.15.7":
+  "@swc/core-win32-ia32-msvc@1.15.8":
     resolution:
       {
-        integrity: sha512-rqq8JjNMLx3QNlh0aPTtN/4+BGLEHC94rj9mkH1stoNRf3ra6IksNHMHy+V1HUqElEgcZyx+0yeXx3eLOTcoFw==,
+        integrity: sha512-/wfAgxORg2VBaUoFdytcVBVCgf1isWZIEXB9MZEUty4wwK93M/PxAkjifOho9RN3WrM3inPLabICRCEgdHpKKQ==,
       }
     engines: { node: ">=10" }
     cpu: [ia32]
     os: [win32]
 
-  "@swc/core-win32-x64-msvc@1.15.7":
+  "@swc/core-win32-x64-msvc@1.15.8":
     resolution:
       {
-        integrity: sha512-4BK06EGdPnuplgcNhmSbOIiLdRgHYX3v1nl4HXo5uo4GZMfllXaCyBUes+0ePRfwbn9OFgVhCWPcYYjMT6hycQ==,
+        integrity: sha512-GpMePrh9Sl4d61o4KAHOOv5is5+zt6BEXCOCgs/H0FLGeii7j9bWDE8ExvKFy2GRRZVNR1ugsnzaGWHKM6kuzA==,
       }
     engines: { node: ">=10" }
     cpu: [x64]
     os: [win32]
 
-  "@swc/core@1.15.7":
+  "@swc/core@1.15.8":
     resolution:
       {
-        integrity: sha512-kTGB8XI7P+pTKW83tnUEDVP4zduF951u3UAOn5eTi0vyW6MvL56A3+ggMdfuVFtDI0/DsbSzf5z34HVBbuScWw==,
+        integrity: sha512-T8keoJjXaSUoVBCIjgL6wAnhADIb09GOELzKg10CjNg+vLX48P93SME6jTfte9MZIm5m+Il57H3rTSk/0kzDUw==,
       }
     engines: { node: ">=10" }
     peerDependencies:
@@ -7794,10 +7797,10 @@ packages:
       }
     engines: { node: ">=12.20" }
 
-  qs@6.14.0:
+  qs@6.14.1:
     resolution:
       {
-        integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==,
+        integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==,
       }
     engines: { node: ">=0.6" }
 
@@ -10589,7 +10592,7 @@ snapshots:
     transitivePeerDependencies:
       - "@algolia/client-search"
 
-  "@docusaurus/babel@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+  "@docusaurus/babel@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
       "@babel/core": 7.28.5
       "@babel/generator": 7.28.5
@@ -10602,7 +10605,7 @@ snapshots:
       "@babel/runtime-corejs3": 7.28.4
       "@babel/traverse": 7.28.5
       "@docusaurus/logger": 3.9.2
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.3
       tslib: 2.8.1
@@ -10615,34 +10618,34 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/bundler@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/bundler@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
       "@babel/core": 7.28.5
-      "@docusaurus/babel": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/babel": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@docusaurus/cssnano-preset": 3.9.2
       "@docusaurus/logger": 3.9.2
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.7))
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.8))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.104.1(@swc/core@1.15.7))
-      css-loader: 6.11.0(@rspack/core@1.6.8)(webpack@5.104.1(@swc/core@1.15.7))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.104.1(@swc/core@1.15.7))
+      copy-webpack-plugin: 11.0.0(webpack@5.104.1(@swc/core@1.15.8))
+      css-loader: 6.11.0(@rspack/core@1.6.8)(webpack@5.104.1(@swc/core@1.15.8))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.104.1(@swc/core@1.15.8))
       cssnano: 6.1.2(postcss@8.5.6)
-      file-loader: 6.2.0(webpack@5.104.1(@swc/core@1.15.7))
+      file-loader: 6.2.0(webpack@5.104.1(@swc/core@1.15.8))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.9.4(webpack@5.104.1(@swc/core@1.15.7))
-      null-loader: 4.0.1(webpack@5.104.1(@swc/core@1.15.7))
+      mini-css-extract-plugin: 2.9.4(webpack@5.104.1(@swc/core@1.15.8))
+      null-loader: 4.0.1(webpack@5.104.1(@swc/core@1.15.8))
       postcss: 8.5.6
-      postcss-loader: 7.3.4(postcss@8.5.6)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.7))
+      postcss-loader: 7.3.4(postcss@8.5.6)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.8))
       postcss-preset-env: 10.5.0(postcss@8.5.6)
-      terser-webpack-plugin: 5.3.16(@swc/core@1.15.7)(webpack@5.104.1(@swc/core@1.15.7))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.15.8)(webpack@5.104.1(@swc/core@1.15.8))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.7)))(webpack@5.104.1(@swc/core@1.15.7))
-      webpack: 5.104.1(@swc/core@1.15.7)
-      webpackbar: 6.0.1(webpack@5.104.1(@swc/core@1.15.7))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.8)))(webpack@5.104.1(@swc/core@1.15.8))
+      webpack: 5.104.1(@swc/core@1.15.8)
+      webpackbar: 6.0.1(webpack@5.104.1(@swc/core@1.15.8))
     optionalDependencies:
-      "@docusaurus/faster": 3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      "@docusaurus/faster": 3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
     transitivePeerDependencies:
       - "@parcel/css"
       - "@rspack/core"
@@ -10658,15 +10661,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/babel": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/bundler": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/babel": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/bundler": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       "@docusaurus/logger": 3.9.2
-      "@docusaurus/mdx-loader": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/mdx-loader": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@mdx-js/react": 3.1.1(@types/react@19.2.7)(react@18.3.1)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -10682,7 +10685,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.3
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.5(@rspack/core@1.6.8)(webpack@5.104.1(@swc/core@1.15.7))
+      html-webpack-plugin: 5.6.5(@rspack/core@1.6.8)(webpack@5.104.1(@swc/core@1.15.8))
       leven: 3.1.0
       lodash: 4.17.21
       open: 8.4.2
@@ -10692,7 +10695,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)"
       react-loadable: "@docusaurus/react-loadable@6.0.0(react@18.3.1)"
-      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.104.1(@swc/core@1.15.7))
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.104.1(@swc/core@1.15.8))
       react-router: 5.3.4(react@18.3.1)
       react-router-config: 5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1)
       react-router-dom: 5.3.4(react@18.3.1)
@@ -10701,9 +10704,9 @@ snapshots:
       tinypool: 1.1.1
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.2(webpack@5.104.1(@swc/core@1.15.7))
+      webpack-dev-server: 5.2.2(webpack@5.104.1(@swc/core@1.15.8))
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
@@ -10738,17 +10741,17 @@ snapshots:
       - supports-color
       - typescript
 
-  "@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))":
+  "@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))":
     dependencies:
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@rspack/core": 1.6.8
-      "@swc/core": 1.15.7
+      "@swc/core": 1.15.8
       "@swc/html": 1.15.7
       browserslist: 4.28.1
       lightningcss: 1.30.2
-      swc-loader: 0.2.6(@swc/core@1.15.7)(webpack@5.104.1(@swc/core@1.15.7))
+      swc-loader: 0.2.6(@swc/core@1.15.8)(webpack@5.104.1(@swc/core@1.15.8))
       tslib: 2.8.1
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
     transitivePeerDependencies:
       - "@swc/helpers"
       - esbuild
@@ -10760,16 +10763,16 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  "@docusaurus/mdx-loader@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+  "@docusaurus/mdx-loader@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
       "@docusaurus/logger": 3.9.2
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@mdx-js/mdx": 3.1.1
       "@slorber/remark-comment": 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.104.1(@swc/core@1.15.7))
+      file-loader: 6.2.0(webpack@5.104.1(@swc/core@1.15.8))
       fs-extra: 11.3.3
       image-size: 2.0.2
       mdast-util-mdx: 3.0.0
@@ -10785,9 +10788,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.7)))(webpack@5.104.1(@swc/core@1.15.7))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.8)))(webpack@5.104.1(@swc/core@1.15.8))
       vfile: 6.0.3
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
     transitivePeerDependencies:
       - "@swc/core"
       - esbuild
@@ -10795,9 +10798,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/module-type-aliases@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+  "@docusaurus/module-type-aliases@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@types/history": 4.7.11
       "@types/react": 19.2.7
       "@types/react-router-config": 5.0.11
@@ -10813,13 +10816,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/plugin-client-redirects@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/plugin-client-redirects@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       "@docusaurus/logger": 3.9.2
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       eta: 2.2.0
       fs-extra: 11.3.3
       lodash: 4.17.21
@@ -10844,17 +10847,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-content-blog@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/plugin-content-blog@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       "@docusaurus/logger": 3.9.2
-      "@docusaurus/mdx-loader": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/plugin-content-docs": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/theme-common": 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/mdx-loader": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/plugin-content-docs": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/theme-common": 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.3.3
@@ -10866,7 +10869,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.0.0
       utility-types: 3.11.0
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -10885,17 +10888,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       "@docusaurus/logger": 3.9.2
-      "@docusaurus/mdx-loader": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/module-type-aliases": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/theme-common": 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/mdx-loader": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/module-type-aliases": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/theme-common": 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@types/react-router-config": 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.3
@@ -10906,7 +10909,7 @@ snapshots:
       schema-dts: 1.1.5
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -10925,18 +10928,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-content-pages@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/plugin-content-pages@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/mdx-loader": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/mdx-loader": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -10955,12 +10958,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-css-cascade-layers@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/plugin-css-cascade-layers@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
@@ -10982,11 +10985,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-debug@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/plugin-debug@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -11010,11 +11013,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-google-analytics@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/plugin-google-analytics@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -11036,11 +11039,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-google-gtag@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/plugin-google-gtag@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@types/gtag.js": 0.0.12
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -11063,11 +11066,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-google-tag-manager@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/plugin-google-tag-manager@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -11089,14 +11092,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-sitemap@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/plugin-sitemap@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       "@docusaurus/logger": 3.9.2
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -11120,18 +11123,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-svgr@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/plugin-svgr@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@svgr/core": 8.1.0(typescript@5.9.3)
       "@svgr/webpack": 8.1.0(typescript@5.9.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -11150,23 +11153,23 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/preset-classic@3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)":
+  "@docusaurus/preset-classic@3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/plugin-content-blog": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/plugin-content-docs": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/plugin-content-pages": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/plugin-css-cascade-layers": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/plugin-debug": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/plugin-google-analytics": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/plugin-google-gtag": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/plugin-google-tag-manager": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/plugin-sitemap": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/plugin-svgr": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/theme-classic": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.6.8)(@swc/core@1.15.7)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/theme-common": 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/theme-search-algolia": 3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/plugin-content-blog": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/plugin-content-docs": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/plugin-content-pages": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/plugin-css-cascade-layers": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/plugin-debug": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/plugin-google-analytics": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/plugin-google-gtag": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/plugin-google-tag-manager": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/plugin-sitemap": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/plugin-svgr": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/theme-classic": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.6.8)(@swc/core@1.15.8)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/theme-common": 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/theme-search-algolia": 3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -11195,21 +11198,21 @@ snapshots:
       "@types/react": 19.2.7
       react: 18.3.1
 
-  "@docusaurus/theme-classic@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.6.8)(@swc/core@1.15.7)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
+  "@docusaurus/theme-classic@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.6.8)(@swc/core@1.15.8)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)":
     dependencies:
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       "@docusaurus/logger": 3.9.2
-      "@docusaurus/mdx-loader": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/module-type-aliases": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/plugin-content-blog": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/plugin-content-docs": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/plugin-content-pages": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/theme-common": 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/mdx-loader": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/module-type-aliases": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/plugin-content-blog": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/plugin-content-docs": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/plugin-content-pages": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/theme-common": 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@docusaurus/theme-translations": 3.9.2
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@mdx-js/react": 3.1.1(@types/react@19.2.7)(react@18.3.1)
       clsx: 2.1.1
       infima: 0.2.0-alpha.45
@@ -11242,13 +11245,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+  "@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      "@docusaurus/mdx-loader": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/module-type-aliases": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/plugin-content-docs": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/mdx-loader": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/module-type-aliases": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/plugin-content-docs": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@types/history": 4.7.11
       "@types/react": 19.2.7
       "@types/react-router-config": 5.0.11
@@ -11266,16 +11269,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/theme-search-algolia@3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)":
+  "@docusaurus/theme-search-algolia@3.9.2(@algolia/client-search@5.46.2)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)":
     dependencies:
       "@docsearch/react": 4.4.0(@algolia/client-search@5.46.2)(@types/react@19.2.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
-      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/core": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       "@docusaurus/logger": 3.9.2
-      "@docusaurus/plugin-content-docs": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      "@docusaurus/theme-common": 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/plugin-content-docs": 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      "@docusaurus/theme-common": 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@18.3.1))(@rspack/core@1.6.8)(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       "@docusaurus/theme-translations": 3.9.2
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-validation": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       algoliasearch: 5.46.2
       algoliasearch-helper: 3.26.1(algoliasearch@5.46.2)
       clsx: 2.1.1
@@ -11312,7 +11315,7 @@ snapshots:
       fs-extra: 11.3.3
       tslib: 2.8.1
 
-  "@docusaurus/types@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+  "@docusaurus/types@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
       "@mdx-js/mdx": 3.1.1
       "@types/history": 4.7.11
@@ -11324,7 +11327,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)"
       utility-types: 3.11.0
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - "@swc/core"
@@ -11333,9 +11336,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/utils-common@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+  "@docusaurus/utils-common@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@swc/core"
@@ -11346,11 +11349,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/utils-validation@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+  "@docusaurus/utils-validation@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
       "@docusaurus/logger": 3.9.2
-      "@docusaurus/utils": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.3
       joi: 17.13.3
       js-yaml: 4.1.1
@@ -11365,14 +11368,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/utils@3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
+  "@docusaurus/utils@3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
     dependencies:
       "@docusaurus/logger": 3.9.2
-      "@docusaurus/types": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/types": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      "@docusaurus/utils-common": 3.9.2(@swc/core@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.104.1(@swc/core@1.15.7))
+      file-loader: 6.2.0(webpack@5.104.1(@swc/core@1.15.8))
       fs-extra: 11.3.3
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -11385,9 +11388,9 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.7)))(webpack@5.104.1(@swc/core@1.15.7))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.8)))(webpack@5.104.1(@swc/core@1.15.8))
       utility-types: 3.11.0
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
     transitivePeerDependencies:
       - "@swc/core"
       - esbuild
@@ -11803,51 +11806,51 @@ snapshots:
       - supports-color
       - typescript
 
-  "@swc/core-darwin-arm64@1.15.7":
+  "@swc/core-darwin-arm64@1.15.8":
     optional: true
 
-  "@swc/core-darwin-x64@1.15.7":
+  "@swc/core-darwin-x64@1.15.8":
     optional: true
 
-  "@swc/core-linux-arm-gnueabihf@1.15.7":
+  "@swc/core-linux-arm-gnueabihf@1.15.8":
     optional: true
 
-  "@swc/core-linux-arm64-gnu@1.15.7":
+  "@swc/core-linux-arm64-gnu@1.15.8":
     optional: true
 
-  "@swc/core-linux-arm64-musl@1.15.7":
+  "@swc/core-linux-arm64-musl@1.15.8":
     optional: true
 
-  "@swc/core-linux-x64-gnu@1.15.7":
+  "@swc/core-linux-x64-gnu@1.15.8":
     optional: true
 
-  "@swc/core-linux-x64-musl@1.15.7":
+  "@swc/core-linux-x64-musl@1.15.8":
     optional: true
 
-  "@swc/core-win32-arm64-msvc@1.15.7":
+  "@swc/core-win32-arm64-msvc@1.15.8":
     optional: true
 
-  "@swc/core-win32-ia32-msvc@1.15.7":
+  "@swc/core-win32-ia32-msvc@1.15.8":
     optional: true
 
-  "@swc/core-win32-x64-msvc@1.15.7":
+  "@swc/core-win32-x64-msvc@1.15.8":
     optional: true
 
-  "@swc/core@1.15.7":
+  "@swc/core@1.15.8":
     dependencies:
       "@swc/counter": 0.1.3
       "@swc/types": 0.1.25
     optionalDependencies:
-      "@swc/core-darwin-arm64": 1.15.7
-      "@swc/core-darwin-x64": 1.15.7
-      "@swc/core-linux-arm-gnueabihf": 1.15.7
-      "@swc/core-linux-arm64-gnu": 1.15.7
-      "@swc/core-linux-arm64-musl": 1.15.7
-      "@swc/core-linux-x64-gnu": 1.15.7
-      "@swc/core-linux-x64-musl": 1.15.7
-      "@swc/core-win32-arm64-msvc": 1.15.7
-      "@swc/core-win32-ia32-msvc": 1.15.7
-      "@swc/core-win32-x64-msvc": 1.15.7
+      "@swc/core-darwin-arm64": 1.15.8
+      "@swc/core-darwin-x64": 1.15.8
+      "@swc/core-linux-arm-gnueabihf": 1.15.8
+      "@swc/core-linux-arm64-gnu": 1.15.8
+      "@swc/core-linux-arm64-musl": 1.15.8
+      "@swc/core-linux-x64-gnu": 1.15.8
+      "@swc/core-linux-x64-musl": 1.15.8
+      "@swc/core-win32-arm64-msvc": 1.15.8
+      "@swc/core-win32-ia32-msvc": 1.15.8
+      "@swc/core-win32-x64-msvc": 1.15.8
 
   "@swc/counter@0.1.3": {}
 
@@ -12341,12 +12344,12 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.7)):
+  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       "@babel/core": 7.28.5
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -12398,7 +12401,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.0
+      qs: 6.14.1
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -12663,7 +12666,7 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.104.1(@swc/core@1.15.7)):
+  copy-webpack-plugin@11.0.0(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -12671,7 +12674,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
 
   core-js-compat@3.47.0:
     dependencies:
@@ -12718,7 +12721,7 @@ snapshots:
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(@rspack/core@1.6.8)(webpack@5.104.1(@swc/core@1.15.7)):
+  css-loader@6.11.0(@rspack/core@1.6.8)(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -12730,9 +12733,9 @@ snapshots:
       semver: 7.7.3
     optionalDependencies:
       "@rspack/core": 1.6.8
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.104.1(@swc/core@1.15.7)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
       cssnano: 6.1.2(postcss@8.5.6)
@@ -12740,7 +12743,7 @@ snapshots:
       postcss: 8.5.6
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
     optionalDependencies:
       clean-css: 5.3.3
 
@@ -13218,7 +13221,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.14.1
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -13277,11 +13280,11 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
-  file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.7)):
+  file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
 
   fill-range@7.1.1:
     dependencies:
@@ -13614,7 +13617,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.5(@rspack/core@1.6.8)(webpack@5.104.1(@swc/core@1.15.7)):
+  html-webpack-plugin@5.6.5(@rspack/core@1.6.8)(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       "@types/html-minifier-terser": 6.1.0
       html-minifier-terser: 6.1.0
@@ -13623,7 +13626,7 @@ snapshots:
       tapable: 2.3.0
     optionalDependencies:
       "@rspack/core": 1.6.8
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -14562,11 +14565,11 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.104.1(@swc/core@1.15.7)):
+  mini-css-extract-plugin@2.9.4(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
 
   minimalistic-assert@1.0.1: {}
 
@@ -14629,11 +14632,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.104.1(@swc/core@1.15.7)):
+  null-loader@4.0.1(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
 
   object-assign@4.1.1: {}
 
@@ -14952,13 +14955,13 @@ snapshots:
       "@csstools/utilities": 2.0.0(postcss@8.5.6)
       postcss: 8.5.6
 
-  postcss-loader@7.3.4(postcss@8.5.6)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.7)):
+  postcss-loader@7.3.4(postcss@8.5.6)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.9.3)
       jiti: 1.21.7
       postcss: 8.5.6
       semver: 7.7.3
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
     transitivePeerDependencies:
       - typescript
 
@@ -15296,7 +15299,7 @@ snapshots:
     dependencies:
       escape-goat: 4.0.0
 
-  qs@6.14.0:
+  qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -15345,11 +15348,11 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.104.1(@swc/core@1.15.7)):
+  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       "@babel/runtime": 7.28.4
       react-loadable: "@docusaurus/react-loadable@6.0.0(react@18.3.1)"
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
 
   react-router-config@5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -15921,11 +15924,11 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
-  swc-loader@0.2.6(@swc/core@1.15.7)(webpack@5.104.1(@swc/core@1.15.7)):
+  swc-loader@0.2.6(@swc/core@1.15.8)(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
-      "@swc/core": 1.15.7
+      "@swc/core": 1.15.8
       "@swc/counter": 0.1.3
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
 
   swr@2.3.8(react@18.3.1):
     dependencies:
@@ -15935,16 +15938,16 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  terser-webpack-plugin@5.3.16(@swc/core@1.15.7)(webpack@5.104.1(@swc/core@1.15.7)):
+  terser-webpack-plugin@5.3.16(@swc/core@1.15.8)(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.1
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
     optionalDependencies:
-      "@swc/core": 1.15.7
+      "@swc/core": 1.15.8
 
   terser@5.44.1:
     dependencies:
@@ -16104,14 +16107,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.7)))(webpack@5.104.1(@swc/core@1.15.7)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.8)))(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.104.1(@swc/core@1.15.7))
+      file-loader: 6.2.0(webpack@5.104.1(@swc/core@1.15.8))
 
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
@@ -16175,7 +16178,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.4.5(webpack@5.104.1(@swc/core@1.15.7)):
+  webpack-dev-middleware@7.4.5(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.51.1
@@ -16184,9 +16187,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
 
-  webpack-dev-server@5.2.2(webpack@5.104.1(@swc/core@1.15.7)):
+  webpack-dev-server@5.2.2(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       "@types/bonjour": 3.5.13
       "@types/connect-history-api-fallback": 1.5.4
@@ -16214,10 +16217,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.15.7))
+      webpack-dev-middleware: 7.4.5(webpack@5.104.1(@swc/core@1.15.8))
       ws: 8.18.3
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16238,7 +16241,7 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack@5.104.1(@swc/core@1.15.7):
+  webpack@5.104.1(@swc/core@1.15.8):
     dependencies:
       "@types/eslint-scope": 3.7.7
       "@types/estree": 1.0.8
@@ -16262,7 +16265,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(@swc/core@1.15.7)(webpack@5.104.1(@swc/core@1.15.7))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.15.8)(webpack@5.104.1(@swc/core@1.15.8))
       watchpack: 2.5.0
       webpack-sources: 3.3.3
     transitivePeerDependencies:
@@ -16270,7 +16273,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@6.0.1(webpack@5.104.1(@swc/core@1.15.7)):
+  webpackbar@6.0.1(webpack@5.104.1(@swc/core@1.15.8)):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -16279,7 +16282,7 @@ snapshots:
       markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.10.0
-      webpack: 5.104.1(@swc/core@1.15.7)
+      webpack: 5.104.1(@swc/core@1.15.8)
       wrap-ansi: 7.0.0
 
   websocket-driver@0.7.4:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,10 @@
 node-linker: hoisted
+
+overrides:
+  qs@<6.14.1: ">=6.14.1"
+
 trustPolicy: no-downgrade
+
 trustPolicyExclude:
   - detect-port@1.6.1
   - semver


### PR DESCRIPTION
The React 19.x change is not a drop-in, so just ignoring it until we're forced to deal with it in Docusaurus 4.x